### PR TITLE
Makefile : fix cleaning rules

### DIFF
--- a/examples/board_ledramp/Makefile
+++ b/examples/board_ledramp/Makefile
@@ -46,4 +46,4 @@ ${target}: ${board}
 	@echo $@ done
 
 clean: clean-${OBJ}
-	rm -rf *.a *.axf ${target} *.vcd
+	rm -rf *.a *.axf ${target} *.vcd *.hex

--- a/examples/board_simduino/Makefile
+++ b/examples/board_simduino/Makefile
@@ -47,4 +47,4 @@ ${target}: ${board}
 	@echo $@ done
 
 clean: clean-${OBJ}
-	rm -rf *.a *.axf ${target} *.vcd
+	rm -rf *.a *.axf ${target} *.vcd *.hex

--- a/examples/board_timer_64led/Makefile
+++ b/examples/board_timer_64led/Makefile
@@ -47,4 +47,4 @@ ${target}: ${board}
 	@echo $@ done
 
 clean: clean-${OBJ}
-	rm -rf *.a *.axf ${target} *.vcd
+	rm -rf *.a *.axf ${target} *.vcd *.hex

--- a/simavr/Makefile
+++ b/simavr/Makefile
@@ -83,6 +83,7 @@ ${target}	: ${OBJ}/${target}.elf
  
 clean: clean-${OBJ}
 	rm -rf ${target} *.a *.so
+	rm -f sim_core_*.h
 
 DESTDIR = /usr/local
 PREFIX = ${DESTDIR}


### PR DESCRIPTION
in order to leave the src tree as clean as before a build
- add rm -f of autogenerated sim_core_config.h & sim_core_decl.h
  in simavr/Makefile
- add rm _.hex in example/board__/Makefile
