### PR TITLE
new global logger, defaults to stdout/stderr

### DIFF
--- a/simavr/sim/avr_uart.c
+++ b/simavr/sim/avr_uart.c
@@ -164,7 +164,7 @@ static void avr_uart_write(struct avr_t * avr, avr_io_addr_t addr, uint8_t v, vo
 			p->stdio_out[p->stdio_len] = 0;
 			if (v == '\n' || p->stdio_len == maxsize) {
 				p->stdio_len = 0;
-				GLOBAL_LOG( LOG_TRACE, FONT_GREEN "%s\n" FONT_DEFAULT, p->stdio_out);
+				AVR_LOG(avr, LOG_TRACE, FONT_GREEN "%s\n" FONT_DEFAULT, p->stdio_out);
 			}
 		}
 		TRACE(printf("UDR%c(%02x) = %02x\n", p->name, addr, v);)

--- a/simavr/sim/sim_avr.c
+++ b/simavr/sim/sim_avr.c
@@ -48,7 +48,7 @@ int avr_init(avr_t * avr)
 	avr->trace_data = calloc(1, sizeof(struct avr_trace_data_t));
 #endif
 	
-	GLOBAL_LOG(LOG_TRACE, "%s init\n", avr->mmcu);
+	AVR_LOG(avr, LOG_TRACE, "%s init\n", avr->mmcu);
 
 	// cpu is in limbo before init is finished.
 	avr->state = cpu_Limbo;
@@ -87,7 +87,7 @@ void avr_terminate(avr_t * avr)
 
 void avr_reset(avr_t * avr)
 {
-	GLOBAL_LOG(LOG_TRACE, "%s reset\n", avr->mmcu);
+	AVR_LOG(avr, LOG_TRACE, "%s reset\n", avr->mmcu);
 
 	memset(avr->data, 0x0, avr->ramend + 1);
 	_avr_sp_set(avr, avr->ramend);
@@ -108,7 +108,7 @@ void avr_reset(avr_t * avr)
 
 void avr_sadly_crashed(avr_t *avr, uint8_t signal)
 {
-	GLOBAL_LOG(LOG_ERROR, "%s\n", __FUNCTION__);
+	AVR_LOG(avr, LOG_ERROR, "%s\n", __FUNCTION__);
 	avr->state = cpu_Stopped;
 	if (avr->gdb_port) {
 		// enable gdb server, and wait
@@ -121,7 +121,7 @@ void avr_sadly_crashed(avr_t *avr, uint8_t signal)
 
 static void _avr_io_command_write(struct avr_t * avr, avr_io_addr_t addr, uint8_t v, void * param)
 {
-	GLOBAL_LOG(LOG_TRACE, "%s %02x\n", __FUNCTION__, v);
+	AVR_LOG(avr, LOG_TRACE, "%s %02x\n", __FUNCTION__, v);
 	switch (v) {
 		case SIMAVR_CMD_VCD_START_TRACE:
 			if (avr->vcd)
@@ -135,7 +135,7 @@ static void _avr_io_command_write(struct avr_t * avr, avr_io_addr_t addr, uint8_
 			avr_irq_t * src = avr_io_getirq(avr, AVR_IOCTL_UART_GETIRQ('0'), UART_IRQ_OUTPUT);
 			avr_irq_t * dst = avr_io_getirq(avr, AVR_IOCTL_UART_GETIRQ('0'), UART_IRQ_INPUT);
 			if (src && dst) {
-				GLOBAL_LOG(LOG_TRACE, "%s activating uart local echo IRQ src %p dst %p\n", __FUNCTION__, src, dst);
+				AVR_LOG(avr, LOG_TRACE, "%s activating uart local echo IRQ src %p dst %p\n", __FUNCTION__, src, dst);
 				avr_connect_irq(src, dst);
 			}
 		}	break;
@@ -156,7 +156,7 @@ static void _avr_io_console_write(struct avr_t * avr, avr_io_addr_t addr, uint8_
 
 	if (v == '\r' && buf) {
 		buf[len] = 0;
-		GLOBAL_LOG(LOG_TRACE, "O:" "%s" "" "\n", buf);
+		AVR_LOG(avr, LOG_TRACE, "O:" "%s" "" "\n", buf);
 		fflush(stdout);
 		len = 0;
 		return;
@@ -178,7 +178,7 @@ void avr_set_console_register(avr_t * avr, avr_io_addr_t addr)
 void avr_loadcode(avr_t * avr, uint8_t * code, uint32_t size, avr_flashaddr_t address)
 {
 	if (size > avr->flashend+1) {
-		GLOBAL_LOG(LOG_ERROR, "avr_loadcode(): Attempted to load code of size %d but flash size is only %d.\n",
+		AVR_LOG(avr, LOG_ERROR, "avr_loadcode(): Attempted to load code of size %d but flash size is only %d.\n",
 			size, avr->flashend+1);
 		abort();
 	}
@@ -244,7 +244,7 @@ void avr_callback_run_gdb(avr_t * avr)
 	if (avr->state == cpu_Sleeping) {
 		if (!avr->sreg[S_I]) {
 			if (avr->log)
-				GLOBAL_LOG(LOG_TRACE, "simavr: sleeping with interrupts off, quitting gracefully\n");
+				AVR_LOG(avr, LOG_TRACE, "simavr: sleeping with interrupts off, quitting gracefully\n");
 			avr->state = cpu_Done;
 			return;
 		}
@@ -298,7 +298,7 @@ void avr_callback_run_raw(avr_t * avr)
 	if (avr->state == cpu_Sleeping) {
 		if (!avr->sreg[S_I]) {
 			if (avr->log)
-				GLOBAL_LOG(LOG_TRACE, "simavr: sleeping with interrupts off, quitting gracefully\n");
+				AVR_LOG(avr, LOG_TRACE, "simavr: sleeping with interrupts off, quitting gracefully\n");
 			avr->state = cpu_Done;
 			return;
 		}
@@ -343,12 +343,12 @@ avr_make_mcu_by_name(
 			}
 	}
 	if (!maker) {
-		GLOBAL_LOG(LOG_ERROR, "%s: AVR '%s' not known\n", __FUNCTION__, name);
+		AVR_LOG(((avr_t*)0), LOG_ERROR, "%s: AVR '%s' not known\n", __FUNCTION__, name);
 		return NULL;
 	}
 
 	avr_t * avr = maker->make();
-	GLOBAL_LOG(LOG_TRACE, "Starting %s - flashend %04x ramend %04x e2end %04x\n", avr->mmcu, avr->flashend, avr->ramend, avr->e2end);
+	AVR_LOG(avr, LOG_TRACE, "Starting %s - flashend %04x ramend %04x e2end %04x\n", avr->mmcu, avr->flashend, avr->ramend, avr->e2end);
 	return avr;	
 }
 

--- a/simavr/sim/sim_avr.h
+++ b/simavr/sim/sim_avr.h
@@ -72,17 +72,13 @@ enum {
 };
 typedef void (*logger_t)(const int level, const char * format, ... );
 extern logger_t global_logger;
-#ifndef GLOBAL_LOG
-#define GLOBAL_LOG(level, ...) \
-	do { \
-		global_logger( level, __VA_ARGS__); \
-	} while(0)
-#endif
+#ifndef AVR_LOG
 #define AVR_LOG(avr, level, ...) \
 	do { \
-		if (avr->log >= level) \
-			GLOBAL_LOG( level, __VA_ARGS__); \
+		if (!avr || avr->log >= level) \
+			global_logger( level, __VA_ARGS__); \
 	} while(0)
+#endif
 
 /*
  * Core states.

--- a/simavr/sim/sim_elf.c
+++ b/simavr/sim/sim_elf.c
@@ -75,7 +75,7 @@ void avr_load_firmware(avr_t * avr, elf_firmware_t * firmware)
 		avr->vcd,
 		firmware->traceperiod >= 1000 ? firmware->traceperiod : 1000);
 	
-	GLOBAL_LOG(LOG_TRACE, "Creating VCD trace file '%s'\n", avr->vcd->filename);
+	AVR_LOG(avr, LOG_TRACE, "Creating VCD trace file '%s'\n", avr->vcd->filename);
 	for (int ti = 0; ti < firmware->tracecount; ti++) {
 		if (firmware->trace[ti].mask == 0xff || firmware->trace[ti].mask == 0) {
 			// easy one
@@ -147,7 +147,7 @@ static void elf_parse_mmcu_section(elf_firmware_t * firmware, uint8_t * src, uin
 				uint8_t mask = src[0];
 				uint16_t addr = src[1] | (src[2] << 8);
 				char * name = (char*)src + 3;
-				GLOBAL_LOG(LOG_TRACE, "AVR_MMCU_TAG_VCD_TRACE %04x:%02x - %s\n", addr, mask, name);
+				AVR_LOG(((avr_t*)0), LOG_TRACE, "AVR_MMCU_TAG_VCD_TRACE %04x:%02x - %s\n", addr, mask, name);
 				firmware->trace[firmware->tracecount].mask = mask;
 				firmware->trace[firmware->tracecount].addr = addr;
 				strncpy(firmware->trace[firmware->tracecount].name, name, 
@@ -181,7 +181,7 @@ int elf_read_firmware(const char * file, elf_firmware_t * firmware)
 
 	if ((fd = open(file, O_RDONLY | O_BINARY)) == -1 ||
 			(read(fd, &elf_header, sizeof(elf_header))) < sizeof(elf_header)) {
-		GLOBAL_LOG(LOG_ERROR, "could not read %s\n", file);
+		AVR_LOG(((avr_t*)0), LOG_ERROR, "could not read %s\n", file);
 		perror(file);
 		close(fd);
 		return -1;
@@ -290,12 +290,12 @@ int elf_read_firmware(const char * file, elf_firmware_t * firmware)
 	//	hdump("code", data_text->d_buf, data_text->d_size);
 		memcpy(firmware->flash + offset, data_text->d_buf, data_text->d_size);
 		offset += data_text->d_size;
-		GLOBAL_LOG(LOG_TRACE, "Loaded %u .text\n", (unsigned int)data_text->d_size);
+		AVR_LOG(((avr_t*)0), LOG_TRACE, "Loaded %u .text\n", (unsigned int)data_text->d_size);
 	}
 	if (data_data) {
 	//	hdump("data", data_data->d_buf, data_data->d_size);
 		memcpy(firmware->flash + offset, data_data->d_buf, data_data->d_size);
-		GLOBAL_LOG(LOG_TRACE, "Loaded %u .data\n", (unsigned int)data_data->d_size);
+		AVR_LOG(((avr_t*)0), LOG_TRACE, "Loaded %u .data\n", (unsigned int)data_data->d_size);
 		offset += data_data->d_size;
 		firmware->datasize = data_data->d_size;
 	}
@@ -303,7 +303,7 @@ int elf_read_firmware(const char * file, elf_firmware_t * firmware)
 	//	hdump("eeprom", data_ee->d_buf, data_ee->d_size);
 		firmware->eeprom = malloc(data_ee->d_size);
 		memcpy(firmware->eeprom, data_ee->d_buf, data_ee->d_size);
-		GLOBAL_LOG(LOG_TRACE, "Loaded %u .eeprom\n", (unsigned int)data_ee->d_size);
+		AVR_LOG(((avr_t*)0), LOG_TRACE, "Loaded %u .eeprom\n", (unsigned int)data_ee->d_size);
 		firmware->eesize = data_ee->d_size;
 	}
 //	hdump("flash", avr->flash, offset);


### PR DESCRIPTION
This is a patch for #8. I tried to make it compatible with the old version by default.
There is a problem with **AVR_LOG** macro: it can not be used without **avr**.
That's why I created a new macro: **GLOBAL_LOG**
