### PR TITLE
Bugfix for potential flash buffer overrun in avr_loadcode (sim_avr.c)

### DIFF
--- a/simavr/sim/sim_avr.c
+++ b/simavr/sim/sim_avr.c
@@ -173,7 +173,7 @@ void avr_set_console_register(avr_t * avr, avr_io_addr_t addr)
 
 void avr_loadcode(avr_t * avr, uint8_t * code, uint32_t size, avr_flashaddr_t address)
 {
-	if (size > avr->flashend+1) {
+	if ((address + size) > avr->flashend+1) {
 		fprintf(stderr, "avr_loadcode(): Attempted to load code of size %d but flash size is only %d.\n",
 			size, avr->flashend+1);
 		abort();


### PR DESCRIPTION
In function avr_loadcode (sim_avr.c) a memcpy is performed to load code
        into flash at address of size block...  However, only the size is
    currently checked against avr->flashend potentially leading to a
    block overrun.

```
modified:   simavr/sim/sim_avr.c
```
