### PR TITLE
elf-symbols-bugfix -- reworked, was elf-symbols-debug

### DIFF
--- a/simavr/sim/sim_avr.h
+++ b/simavr/sim/sim_avr.h
@@ -96,9 +96,16 @@ enum {
 	cpu_Crashed,    // avr software crashed (watchdog fired)
 };
 
+// a symbol loaded from the .elf file
+typedef struct avr_symbol_t {
+	const char *	symbol;
+	avr_flashaddr_t	addr;
+} avr_symbol_t;
+
 // this is only ever used if CONFIG_SIMAVR_TRACE is defined
 struct avr_trace_data_t {
-	struct avr_symbol_t ** codeline;
+	avr_symbol_t 		(*codeline)[];
+	uint32_t		codesize;
 
 	/* DEBUG ONLY
 	 * this keeps track of "jumps" ie, call,jmp,ret,reti and so on
@@ -292,11 +299,21 @@ typedef struct avr_kind_t {
 	avr_t * (*make)();
 } avr_kind_t;
 
-// a symbol loaded from the .elf file
-typedef struct avr_symbol_t {
-	const char * symbol;
-	uint32_t	addr;
-} avr_symbol_t;
+static inline avr_symbol_t *avr_symbol_for_address(avr_t *avr, avr_flashaddr_t addr) {
+	for(int index = 0; index < avr->trace_data->codesize; index++) {
+		avr_symbol_t *symbol = &(*avr->trace_data->codeline)[index];
+		if(addr == symbol->addr)
+			return(symbol);
+	}
+
+	return(0);
+}
+
+static inline const char *avr_symbol_name_for_address(avr_t *avr, avr_flashaddr_t addr) {
+	avr_symbol_t *symbol = avr_symbol_for_address(avr, addr);
+
+	return((0 != symbol) ? symbol->symbol : 0);
+}
 
 // locate the maker for mcu "name" and allocates a new avr instance
 avr_t *

--- a/simavr/sim/sim_core.c
+++ b/simavr/sim/sim_core.c
@@ -64,8 +64,9 @@ int donttrace = 0;
 
 #define STATE(_f, args...) { \
 	if (avr->trace) {\
-		if (avr->trace_data->codeline && avr->trace_data->codeline[avr->pc>>1]) {\
-			const char * symn = avr->trace_data->codeline[avr->pc>>1]->symbol; \
+		avr_symbol_t*	symbol = avr_symbol_for_address(avr, avr->pc >> 1); \
+		if (symbol) {\
+			const char * symn = symbol->symbol; \
 			int dont = 0 && dont_trace(symn);\
 			if (dont!=donttrace) { \
 				donttrace = dont;\
@@ -281,7 +282,8 @@ static void _avr_invalid_opcode(avr_t * avr)
 {
 #if CONFIG_SIMAVR_TRACE
 	printf( FONT_RED "*** %04x: %-25s Invalid Opcode SP=%04x O=%04x \n" FONT_DEFAULT,
-			avr->pc, avr->trace_data->codeline[avr->pc>>1]->symbol, _avr_sp_get(avr), avr->flash[avr->pc] | (avr->flash[avr->pc+1]<<8));
+			avr->pc, avr_symbol_name_for_address(avr, avr->pc >> 1),
+			_avr_sp_get(avr), avr->flash[avr->pc] | (avr->flash[avr->pc+1]<<8));
 #else
 	AVR_LOG(avr, LOG_ERROR, FONT_RED "CORE: *** %04x: Invalid Opcode SP=%04x O=%04x \n" FONT_DEFAULT,
 			avr->pc, _avr_sp_get(avr), avr->flash[avr->pc] | (avr->flash[avr->pc+1]<<8));

--- a/simavr/sim/sim_core.h
+++ b/simavr/sim/sim_core.h
@@ -74,9 +74,10 @@ void avr_dump_state(avr_t * avr);
 #define DUMP_STACK() \
 		for (int i = avr->trace_data->stack_frame_index; i; i--) {\
 			int pci = i-1;\
+			const char * symbolName = avr_symbol_name_for_address(avr, avr->trace_data->stack_frame[pci].pc);
 			printf(FONT_RED "*** %04x: %-25s sp %04x\n" FONT_DEFAULT,\
 					avr->trace_data->stack_frame[pci].pc, \
-					avr->trace_data->codeline ? avr->trace_data->codeline[avr->trace_data->stack_frame[pci].pc>>1]->symbol : "unknown", \
+					(symbolName ? symbolName : "unknown"), \
 							avr->trace_data->stack_frame[pci].sp);\
 		}
 #else
@@ -88,8 +89,11 @@ void avr_dump_state(avr_t * avr);
 		printf("*** CYCLE %" PRI_avr_cycle_count "PC %04x\n", avr->cycle, avr->pc);\
 		for (int i = OLD_PC_SIZE-1; i > 0; i--) {\
 			int pci = (avr->trace_data->old_pci + i) & 0xf;\
+			const char * symbolName = avr_symbol_name_for_address(avr, avr->trace_data->old[pci].pc>>1);\
 			printf(FONT_RED "*** %04x: %-25s RESET -%d; sp %04x\n" FONT_DEFAULT,\
-					avr->trace_data->old[pci].pc, avr->trace_data->codeline ? avr->trace_data->codeline[avr->trace_data->old[pci].pc>>1]->symbol : "unknown", OLD_PC_SIZE-i, avr->trace_data->old[pci].sp);\
+					avr->trace_data->old[pci].pc,\
+					(symbolName ? symbolName : "unknown"),\
+					OLD_PC_SIZE-i, avr->trace_data->old[pci].sp);\
 		}\
 		printf("Stack Ptr %04x/%04x = %d \n", _avr_sp_get(avr), avr->ramend, avr->ramend - _avr_sp_get(avr));\
 		DUMP_STACK();\

--- a/simavr/sim/sim_elf.c
+++ b/simavr/sim/sim_elf.c
@@ -50,7 +50,9 @@ void avr_load_firmware(avr_t * avr, elf_firmware_t * firmware)
 		avr->avcc = firmware->avcc;
 	if (firmware->aref)
 		avr->aref = firmware->aref;
+
 #if CONFIG_SIMAVR_TRACE
+	avr->trace_data->codesize = firmware->codesize;
 	avr->trace_data->codeline = firmware->codeline;
 #endif
 
@@ -198,12 +200,9 @@ int elf_read_firmware(const char * file, elf_firmware_t * firmware)
 		*data_ee = NULL;                /* Data Descriptor */
 
 	memset(firmware, 0, sizeof(*firmware));
+
 #if ELF_SYMBOLS
-	//int bitesize = ((avr->flashend+1) >> 1) * sizeof(avr_symbol_t);
-	firmware->codesize = 32768;
-	int bitesize = firmware->codesize * sizeof(avr_symbol_t);
-	firmware->codeline = malloc(bitesize);
-	memset(firmware->codeline,0, bitesize);
+	firmware->codeline=NULL;
 #endif
 
 	/* this is actually mandatory !! otherwise elf_begin() fails */
@@ -247,6 +246,13 @@ int elf_read_firmware(const char * file, elf_firmware_t * firmware)
 			// the section divided by the entry size
 			int symbol_count = shdr.sh_size / shdr.sh_entsize;
 
+			firmware->codesize = symbol_count;
+
+			// use the symbol_count to allocate for that many symbols.
+			uint32_t bitesize = (symbol_count + 1) * sizeof(avr_symbol_t);
+			firmware->codeline = malloc(bitesize);
+			memset(firmware->codeline,0, bitesize);
+
 			// loop through to grab all symbols
 			for (int i = 0; i < symbol_count; i++) {
 				GElf_Sym sym;			/* Symbol */
@@ -259,32 +265,20 @@ int elf_read_firmware(const char * file, elf_firmware_t * firmware)
 						ELF32_ST_TYPE(sym.st_info) == STT_FUNC || 
 						ELF32_ST_TYPE(sym.st_info) == STT_OBJECT) {
 					const char * name = elf_strptr(elf, shdr.sh_link, sym.st_name);
+					avr_symbol_t * s = &(*firmware->codeline)[i];
 
 					// type of symbol
 					if (sym.st_value & 0xfff00000) {
-
 					} else {
-						// code
-						if (firmware->codeline[sym.st_value >> 1] == NULL) {
-							avr_symbol_t * s = firmware->codeline[sym.st_value >> 1] = malloc(sizeof(avr_symbol_t));
-							s->symbol = strdup(name);
-							s->addr = sym.st_value;
-						}
+						s->symbol = strdup(name);
+						s->addr = sym.st_value;
 					}
 				}
 			}
 		}
 #endif
 	}
-#if ELF_SYMBOLS
-	avr_symbol_t * last = NULL;
-	for (int i = 0; i < firmware->codesize; i++) {
-		if (!firmware->codeline[i])
-			firmware->codeline[i] = last;
-		else
-			last = firmware->codeline[i];
-	}
-#endif
+
 	uint32_t offset = 0;
 	firmware->flashsize =
 			(data_text ? data_text->d_size : 0) +

--- a/simavr/sim/sim_elf.h
+++ b/simavr/sim/sim_elf.h
@@ -68,7 +68,7 @@ typedef struct elf_firmware_t {
 	uint32_t 	eesize;
 
 #if ELF_SYMBOLS
-	avr_symbol_t **  codeline;
+	avr_symbol_t		(*codeline)[];
 	uint32_t		codesize;	// in elements
 #endif
 } elf_firmware_t ;


### PR DESCRIPTION
method of storing symbols was discovered overruning bounds as implimented.

original code loaded symbols from elf file into array using the address of symbol.
new code uses incremental index into the symbol table array.
