### PR TITLE
Deadlock fix adapted from https://groups.google.com/forum/#!searchin/simavr/parts%242Fuart_pty%2420not%2420threadsafe/simavr/eSVV90dFh8U/XwQmSIlrNMIJ

### DIFF
--- a/examples/parts/uart_pty.c
+++ b/examples/parts/uart_pty.c
@@ -57,7 +57,7 @@ uart_pty_in_hook(
 		void * param)
 {
 	uart_pty_t * p = (uart_pty_t*)param;
-    LOCK_MUTEX;
+	LOCK_MUTEX;
 	TRACE(printf("uart_pty_in_hook %02x\n", value);)
 	uart_pty_fifo_write(&p->pty.in, value);
 
@@ -66,7 +66,7 @@ uart_pty_in_hook(
 			uart_pty_fifo_write(&p->tap.in, '\r');
 		uart_pty_fifo_write(&p->tap.in, value);
 	}
-    UNLOCK_MUTEX;
+	UNLOCK_MUTEX;
 }
 
 // try to empty our fifo, the uart_pty_xoff_hook() will be called when
@@ -75,7 +75,7 @@ static void
 uart_pty_flush_incoming(
 		uart_pty_t * p)
 {
-    LOCK_MUTEX;
+	LOCK_MUTEX;
 	while (p->xon && !uart_pty_fifo_isempty(&p->pty.out)) {
 		uint8_t byte = uart_pty_fifo_read(&p->pty.out);
 		TRACE(printf("uart_pty_flush_incoming send %02x\n", byte);)
@@ -99,7 +99,7 @@ uart_pty_flush_incoming(
 			avr_raise_irq(p->irq + IRQ_UART_PTY_BYTE_OUT, byte);
 		}
 	}
-    UNLOCK_MUTEX;
+	UNLOCK_MUTEX;
 }
 
 /*
@@ -148,15 +148,15 @@ uart_pty_thread(
 			// read more only if buffer was flushed
 			if (p->port[ti].buffer_len == p->port[ti].buffer_done) {
 				LOCK_MUTEX;
-                FD_SET(p->port[ti].s, &read_set);
+				FD_SET(p->port[ti].s, &read_set);
 				max = p->port[ti].s > max ? p->port[ti].s : max;
-                UNLOCK_MUTEX;
+				UNLOCK_MUTEX;
 			}
 			if (!uart_pty_fifo_isempty(&p->port[ti].in)) {
-                LOCK_MUTEX;
+				LOCK_MUTEX;
 				FD_SET(p->port[ti].s, &write_set);
 				max = p->port[ti].s > max ? p->port[ti].s : max;
-                UNLOCK_MUTEX;
+				UNLOCK_MUTEX;
 			}
 		}
 
@@ -170,24 +170,24 @@ uart_pty_thread(
 
 		for (int ti = 0; ti < 2; ti++) if (p->port[ti].s) {
 			if (FD_ISSET(p->port[ti].s, &read_set)) {
-                LOCK_MUTEX;
+				LOCK_MUTEX;
 				ssize_t r = read(p->port[ti].s, p->port[ti].buffer, sizeof(p->port[ti].buffer)-1);
 				p->port[ti].buffer_len = r;
 				p->port[ti].buffer_done = 0;
 				TRACE(hdump("pty recv", p->port[ti].buffer, r);)
-                UNLOCK_MUTEX;
+				UNLOCK_MUTEX;
 			}
 			if (p->port[ti].buffer_done < p->port[ti].buffer_len) {
 				// write them in fifo
-                LOCK_MUTEX;
+				LOCK_MUTEX;
 				while (p->port[ti].buffer_done < p->port[ti].buffer_len &&
 						!uart_pty_fifo_isfull(&p->port[ti].out))
 					uart_pty_fifo_write(&p->port[ti].out,
 							p->port[ti].buffer[p->port[ti].buffer_done++]);
-                UNLOCK_MUTEX;
+				UNLOCK_MUTEX;
 			}
 			if (FD_ISSET(p->port[ti].s, &write_set)) {
-                LOCK_MUTEX;
+				LOCK_MUTEX;
 				uint8_t buffer[512];
 				// write them in fifo
 				uint8_t * dst = buffer;
@@ -197,7 +197,7 @@ uart_pty_thread(
 				size_t len = dst - buffer;
 				TRACE(size_t r =) write(p->port[ti].s, buffer, len);
 				TRACE(hdump("pty send", buffer, r);)
-                UNLOCK_MUTEX;
+				UNLOCK_MUTEX;
 			}
 		}
 		uart_pty_flush_incoming(p);
@@ -242,7 +242,7 @@ uart_pty_init(
 				ti == 0 ? "bridge" : "tap", p->port[ti].slavename);
 	}
 
-    pthread_mutex_init(&p->lock, NULL);
+	pthread_mutex_init(&p->lock, NULL);
 	pthread_create(&p->thread, NULL, uart_pty_thread, p);
 
 }

--- a/examples/parts/uart_pty.h
+++ b/examples/parts/uart_pty.h
@@ -50,7 +50,7 @@ typedef struct uart_pty_t {
 	struct avr_t *avr;		// keep it around so we can pause it
 
 	pthread_t	thread;
-    pthread_mutex_t    lock;
+	pthread_mutex_t	lock;
 	int			xon;
 
 	union {


### PR DESCRIPTION
simduino example had deadlock issues on multi-core hosts (which I imagine is virtually all these days). Patch from mailing list did not apply cleanly so I had to apply some of it by hand.

Original patch here:

https://groups.google.com/forum/#!searchin/simavr/parts$2Fuart_pty$20not$20threadsafe/simavr/eSVV90dFh8U/XwQmSIlrNMIJ

Didn't apply cleanly so I had to do some of it by hand.

Fixes issue that showed up like then when doing the avrdude programming of the simduino which had output like this:

```
# avrdude -p m328p -c arduino -P /tmp/simavr-uart0 -U flash:w:atmega328p_dummy_blinky.hex
ioctl("TIOCMGET"): Invalid argument
ioctl("TIOCMGET"): Invalid argument
avrdude: stk500_recv(): programmer is not responding
ioctl("TIOCMGET"): Invalid argument

avrdude done.  Thank you.
```

After patch output indicates success:

```
# avrdude -p m328p -c arduino -P /tmp/simavr-uart0 -U flash:w:atmega328p_dummy_blinky.hex                
ioctl("TIOCMGET"): Invalid argument                
ioctl("TIOCMGET"): Invalid argument                

avrdude: AVR device initialized and ready to accept instructions                

Reading | ################################################## | 100% 0.00s                

avrdude: Device signature = 0x1e950f                
avrdude: NOTE: FLASH memory has been specified, an erase cycle will be performed                
         To disable this feature, specify the -D option.                
avrdude: erasing chip                
avrdude: reading input file "atmega328p_dummy_blinky.hex"                
avrdude: input file atmega328p_dummy_blinky.hex auto detected as Intel Hex                
avrdude: writing flash (446 bytes):                

Writing | ################################################## | 100% 0.05s                

avrdude: 446 bytes of flash written                
avrdude: verifying flash memory against atmega328p_dummy_blinky.hex:                
avrdude: load data flash data from input file atmega328p_dummy_blinky.hex:                
avrdude: input file atmega328p_dummy_blinky.hex auto detected as Intel Hex                
avrdude: input file atmega328p_dummy_blinky.hex contains 446 bytes                
avrdude: reading on-chip flash data:                

Reading | ################################################## | 100% 0.05s                

avrdude: verifying ...                
avrdude: 446 bytes of flash verified                

avrdude: safemode: Fuses OK                
ioctl("TIOCMGET"): Invalid argument                

avrdude done.  Thank you.
```
