### PR TITLE
sim_core.c: fix implimentation of inc/dec to match specification

### DIFF
--- a/simavr/sim/sim_core.c
+++ b/simavr/sim/sim_core.c
@@ -1080,7 +1080,7 @@ avr_flashaddr_t avr_run_one(avr_t * avr)
 							_avr_set_r(avr, r, res);
 							avr->sreg[S_Z] = res == 0;
 							avr->sreg[S_N] = res >> 7;
-							avr->sreg[S_V] = res == 0x7f;
+							avr->sreg[S_V] = res == 0x80;
 							avr->sreg[S_S] = avr->sreg[S_N] ^ avr->sreg[S_V];
 							SREG();
 						}	break;
@@ -1130,7 +1130,7 @@ avr_flashaddr_t avr_run_one(avr_t * avr)
 							_avr_set_r(avr, r, res);
 							avr->sreg[S_Z] = res == 0;
 							avr->sreg[S_N] = res >> 7;
-							avr->sreg[S_V] = res == 0x80;
+							avr->sreg[S_V] = res == 0x7f;
 							avr->sreg[S_S] = avr->sreg[S_N] ^ avr->sreg[S_V];
 							SREG();
 						}	break;


### PR DESCRIPTION
the avr instruction manual states that overflow be set _before_ the operation takes place, however the core tests based on the result.  values checked adjusted accordingly.

bug find credit goes to: Shay Green gblargg@gmail.com
