### PR TITLE
Correctly set timer1's ICP on atmega8, atmega16 and atmega32.

### DIFF
--- a/simavr/cores/sim_mega16.c
+++ b/simavr/cores/sim_mega16.c
@@ -27,6 +27,9 @@
 #define SIM_MMCU		"atmega16"
 #define SIM_CORENAME	mcu_mega16
 
+#define ICP_PORT	PORTD
+#define ICP_PIN		6
+	
 #define _AVR_IO_H_
 #define __ASSEMBLER__
 #include "avr/iom16.h"

--- a/simavr/cores/sim_mega32.c
+++ b/simavr/cores/sim_mega32.c
@@ -27,6 +27,9 @@
 #define SIM_MMCU		"atmega32"
 #define SIM_CORENAME	mcu_mega32
 
+#define ICP_PORT	PORTD
+#define ICP_PIN		6
+
 #define _AVR_IO_H_
 #define __ASSEMBLER__
 #include "avr/iom32.h"

--- a/simavr/cores/sim_mega8.c
+++ b/simavr/cores/sim_mega8.c
@@ -25,6 +25,9 @@
 #define SIM_MMCU		"atmega8"
 #define SIM_CORENAME	mcu_mega8
 
+#define ICP_PORT	PORTB
+#define ICP_PIN		0
+
 #define _AVR_IO_H_
 #define __ASSEMBLER__
 #include "avr/iom8.h"

--- a/simavr/cores/sim_megax.h
+++ b/simavr/cores/sim_megax.h
@@ -211,7 +211,7 @@ const struct mcu_t SIM_CORENAME = {
 		.r_tcnth = TCNT1H,
 
 		.ices = AVR_IO_REGBIT(TCCR1B, ICES1),
-		.icp = AVR_IO_REGBIT(PORTD, 4),
+		.icp = AVR_IO_REGBIT(ICP_PORT, ICP_PIN),
 
 		.overflow = {
 			.enable = AVR_IO_REGBIT(TIMSK, TOIE1),


### PR DESCRIPTION
If the #define approach is not acceptable, please tell me. Seemed to be the easiest way.
