### PR TITLE
Extend special_init/special_deinit API

### DIFF
--- a/examples/board_simduino/simduino.c
+++ b/examples/board_simduino/simduino.c
@@ -145,42 +145,46 @@ static void * avr_run_thread(void * oaram)
 	return NULL;
 }
 
-
-char avr_flash_path[1024];
-int avr_flash_fd = 0;
+struct avr_flash {
+	char avr_flash_path[1024];
+	int avr_flash_fd;
+};
 
 // avr special flash initalization
 // here: open and map a file to enable a persistent storage for the flash memory
-void avr_special_init( avr_t * avr)
+void avr_special_init( avr_t * avr, void * data)
 {
+	struct avr_flash *flash_data = (struct avr_flash *)data;
 	// open the file
-	avr_flash_fd = open(avr_flash_path, O_RDWR|O_CREAT, 0644);
-	if (avr_flash_fd < 0) {
-		perror(avr_flash_path);
+	avr_flash_fd = open(flash_data->avr_flash_path, O_RDWR|O_CREAT, 0644);
+	if (flash_data->avr_flash_fd < 0) {
+		perror(flash_data->avr_flash_path);
 		exit(1);
 	}
 	// resize and map the file the file
-	(void)ftruncate(avr_flash_fd, avr->flashend + 1);
-	ssize_t r = read(avr_flash_fd, avr->flash, avr->flashend + 1);
+	(void)ftruncate(flash_data->avr_flash_fd, avr->flashend + 1);
+	ssize_t r = read(flash_data->avr_flash_fd, avr->flash, avr->flashend + 1);
 	if (r != avr->flashend + 1) {
 		fprintf(stderr, "unable to load flash memory\n");
-		perror(avr_flash_path);
+		perror(flash_data->avr_flash_path);
 		exit(1);
 	}
 }
 
 // avr special flash deinitalization
 // here: cleanup the persistent storage
-void avr_special_deinit( avr_t* avr)
+void avr_special_deinit( avr_t* avr, void * data)
 {
+	struct avr_flash *flash_data = (struct avr_flash *)data;
+
 	puts(__func__);
-	lseek(avr_flash_fd, SEEK_SET, 0);
-	ssize_t r = write(avr_flash_fd, avr->flash, avr->flashend + 1);
+	lseek(flash_data->avr_flash_fd, SEEK_SET, 0);
+	ssize_t r = write(flash_data->avr_flash_fd, avr->flash, avr->flashend + 1);
 	if (r != avr->flashend + 1) {
 		fprintf(stderr, "unable to load flash memory\n");
-		perror(avr_flash_path);
+		perror(flash_data->avr_flash_path);
 	}
-	close(avr_flash_fd);
+	close(flash_data->avr_flash_fd);
 	uart_pty_stop(&uart_pty);
 }
 
@@ -188,6 +192,7 @@ int main(int argc, char *argv[])
 {
 	//elf_firmware_t f;
 	//const char * pwd = dirname(argv[0]);
+	struct avr_flash flash_data;
 
 	avr = avr_make_mcu_by_name("atmega328p");
 	if (!avr) {
@@ -195,10 +200,12 @@ int main(int argc, char *argv[])
 		exit(1);
 	}
 //	snprintf(avr_flash_path, sizeof(avr_flash_path), "%s/%s", pwd, "simduino_flash.bin");
-	strcpy(avr_flash_path,  "simduino_flash.bin");
+	strcpy(flash_data.avr_flash_path,  "simduino_flash.bin");
+	flash_data.avr_flash_fd = 0;
 	// register our own functions
 	avr->special_init = avr_special_init;
 	avr->special_deinit = avr_special_deinit;
+	avr->special_data = &flash_data;
 	//avr->reset = NULL;
 	avr_init(avr);
 	avr->frequency = 16000000;

--- a/simavr/sim/sim_avr.c
+++ b/simavr/sim/sim_avr.c
@@ -83,7 +83,7 @@ int avr_init(avr_t * avr)
 	avr->frequency = 1000000;	// can be overridden via avr_mcu_section
 	avr_interrupt_init(avr);
 	if (avr->special_init)
-		avr->special_init(avr);
+		avr->special_init(avr, avr->special_data);
 	if (avr->init)
 		avr->init(avr);
 	// set default (non gdb) fast callbacks
@@ -98,7 +98,7 @@ int avr_init(avr_t * avr)
 void avr_terminate(avr_t * avr)
 {
 	if (avr->special_deinit)
-		avr->special_deinit(avr);
+		avr->special_deinit(avr, avr->special_data);
 	if (avr->gdb) {
 		avr_deinit_gdb(avr);
 		avr->gdb = NULL;

--- a/simavr/sim/sim_avr.h
+++ b/simavr/sim/sim_avr.h
@@ -167,13 +167,15 @@ typedef struct avr_t {
 	 * is passed on to the operating system.
 	 */
 	uint32_t sleep_usec;
-	
+
 	// called at init time
 	void (*init)(struct avr_t * avr);
 	// called at init time (for special purposes like using a memory mapped file as flash see: simduino)
-	void (*special_init)(struct avr_t * avr);
+	void (*special_init)(struct avr_t * avr, void * data);
 	// called at termination time ( to clean special initializations)
-	void (*special_deinit)(struct avr_t * avr);
+	void (*special_deinit)(struct avr_t * avr, void * data);
+    // value passed to special_init() and special_deinit()
+	void *special_data;
 	// called at reset time
 	void (*reset)(struct avr_t * avr);
 

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -54,7 +54,7 @@ cycle_timer_longjmp_cb(struct avr_t *avr, avr_cycle_count_t when, void *param) {
 
 static jmp_buf *special_deinit_jmpbuf = NULL;
 
-static void special_deinit_longjmp_cb(struct avr_t *avr) {
+static void special_deinit_longjmp_cb(struct avr_t *avr, void *data) {
 	if (special_deinit_jmpbuf)
 		longjmp(*special_deinit_jmpbuf, LJR_SPECIAL_DEINIT);
 }


### PR DESCRIPTION
Its pretty common for callback style APIs to include a private pointer
to allow the user to pass in contextual data through the callback API
(see pthread_create for an example). This change adds that for
special_init() and special_deinit() which are designed as callbacks.
Effectively this behavior was used in the only two examples that used
those callbacks by having global variables, however globals are of
limited use for programs that might instantiate multiple avr cores.
