### PR TITLE
Freebsd build fix

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -55,7 +55,7 @@ IPATH		+= /opt/local/include
 LFLAGS		= -L/opt/local/lib/
 endif
 else
-LINUX_AVR_ROOTS := /usr/lib/avr /usr/avr /opt/cross/avr/avr
+LINUX_AVR_ROOTS := /usr/lib/avr /usr/avr /opt/cross/avr/avr /usr/local/avr
 AVR_ROOT := $(firstword $(wildcard $(LINUX_AVR_ROOTS)))
 ifeq (${AVR_ROOT},)
 $(error No avr-libc root directory found. Tried the following paths: $(LINUX_AVR_ROOTS))

--- a/examples/Makefile.opengl
+++ b/examples/Makefile.opengl
@@ -11,8 +11,10 @@ else
 ifeq (${shell uname -o}, Msys)
 LDFLAGS 	+= -mwindows -lopengl32 -lfreeglut
 else
+CPPFLAGS	+= ${shell pkg-config --cflags gl}
 CPPFLAGS	+= ${shell pkg-config --cflags glu glut} -DFREEBSD=1
-LDFLAGS 	+= ${shell pkg-config --libs glu glut}
+LDFLAGS 	+= ${shell pkg-config --libs gl}
+LDFLAGS 	+= ${shell pkg-config --libs glu glut} -lglut
 endif
 endif
 endif


### PR DESCRIPTION
I had a few issues building on FreeBSD 9.2. The LINUX_AVR_ROOTS was not general enough since BSD uses /usr/local/avr for its avr-libc directory. Also, FreeBSD uses freeglut for its glut implementation. Unfortunately, freeglut doesn't provide a pkg-config file. As a workaround, I was able to pull in the gl package with pkg-config and explicitly pass -lglut and get it to link.
