### PR TITLE
Fix avr_global_logger_get() decl  to not warn

### DIFF
--- a/simavr/sim/sim_avr.c
+++ b/simavr/sim/sim_avr.c
@@ -60,7 +60,7 @@ avr_global_logger_set(
 }
 
 avr_logger_p
-avr_global_logger_get()
+avr_global_logger_get(void)
 {
 	return _avr_global_logger;
 }

--- a/simavr/sim/sim_avr.h
+++ b/simavr/sim/sim_avr.h
@@ -398,7 +398,7 @@ avr_global_logger_set(
 		avr_logger_p logger);
 /* Gets the current global logger function */
 avr_logger_p
-avr_global_logger_get();
+avr_global_logger_get(void);
 #endif
 
 /*


### PR DESCRIPTION
When using sim_avr.h with a project that uses -Wstrict-prototypes, you
will get a warning that the prototype for avr_global_logger_get() is not
valid. Functions that take no args must explicitly use void to not warn.
