### PR TITLE
sim_interupts: simplification of interrupt handling

### DIFF
--- a/simavr/sim/run_avr.c
+++ b/simavr/sim/run_avr.c
@@ -162,9 +162,9 @@ int main(int argc, char *argv[])
 	avr->log = (log > LOG_TRACE ? LOG_TRACE : log);
 	avr->trace = trace;
 	for (int ti = 0; ti < trace_vectors_count; ti++) {
-		for (int vi = 0; vi < avr->interrupts.vector_count; vi++)
-			if (avr->interrupts.vector[vi]->vector == trace_vectors[ti])
-				avr->interrupts.vector[vi]->trace = 1;
+		avr_int_vector_t *vector = avr->interrupts.vector[trace_vectors[ti]];
+		if (vector)
+			vector->trace = 1;
 	}
 
 	// even if not setup at startup, activate gdb if crashing

--- a/simavr/sim/sim_interrupts.h
+++ b/simavr/sim/sim_interrupts.h
@@ -29,9 +29,12 @@
 extern "C" {
 #endif
 
+typedef struct  avr_int_table_t *avr_int_table_p;
+
 // interrupt vector for the IO modules
 typedef struct avr_int_vector_t {
 	uint8_t 		vector;			// vector number, zero (reset) is reserved
+	avr_int_table_p		table;
 	avr_regbit_t 	enable;			// IO register index for the "interrupt enable" flag for this vector
 	avr_regbit_t 	raised;			// IO register index for the register where the "raised" flag is (optional)
 
@@ -45,12 +48,9 @@ typedef struct avr_int_vector_t {
 // interrupt vectors, and their enable/clear registers
 typedef struct  avr_int_table_t {
 	avr_int_vector_t * vector[64];
-	uint8_t			vector_count;
 	uint8_t			pending_wait;	// number of cycles to wait for pending
-	avr_int_vector_t * pending[64]; // needs to be >= vectors and a power of two
-	uint8_t			pending_w,
-					pending_r;	// fifo cursors
-} avr_int_table_t, *avr_int_table_p;
+	uint64_t		pending_vector_bitmap;
+} avr_int_table_t;
 
 /*
  * Interrupt Helper Functions


### PR DESCRIPTION
changes interrupt handling use of fifo to a more simple and less
 complex bitmap approach.  for interrupt intensive simulations this
 can save hundres of cycles per interrupt.

the fifo approach touches memory to sort and check the queue,
 dependent on number of interrupts in queue...  using bitmaps
 setting and clearing interupts is more alu dependant ie. in
 register/processor and relatively independant of number of
 interrupts...  the ffs() function, or find first set, is used
 since this may be tailored to use processor features available
 relative to a native build.

```
modified:   simavr/sim/run_avr.c
modified:   simavr/sim/sim_interrupts.c
modified:   simavr/sim/sim_interrupts.h
```
