### PR TITLE
avr_timer: refactor avr_timer_write and avr_timer_reconfigure

### DIFF
--- a/simavr/sim/avr_timer.h
+++ b/simavr/sim/avr_timer.h
@@ -109,10 +109,15 @@ typedef struct avr_timer_t {
 
 	avr_regbit_t	wgm[4];
 	avr_timer_wgm_t	wgm_op[16];
+	avr_timer_wgm_t	mode;
+	int		wgm_op_mode_kind;
+	uint32_t	wgm_op_mode_size;
 
-	avr_regbit_t	cs[4];
-	uint8_t			cs_div[16];
 	avr_regbit_t	as2;		// asynchronous clock 32khz
+	avr_regbit_t	cs[4];
+	uint8_t		cs_div[16];
+	uint32_t	cs_div_clock;
+
 	avr_regbit_t	icp;		// input capture pin, to link IRQs
 	avr_regbit_t	ices;		// input capture edge select
 
@@ -121,7 +126,6 @@ typedef struct avr_timer_t {
 	avr_int_vector_t overflow;	// overflow
 	avr_int_vector_t icr;	// input capture
 
-	avr_timer_wgm_t	mode;
 	uint64_t		tov_cycles;
 	uint64_t		tov_base;	// when we last were called
 	uint16_t		tov_top;	// current top value to calculate tnct


### PR DESCRIPTION
avr_timer_reconfigure: calculations moved back in call chain to
 avr_timer_write.

avr_timer_write_ocr: use data processed in avr_timer_write.

avr_timer_init: changed to fully trap writes going to as2,
 clock select bits and waveform generation mode bits.

```
modified:   ../../simavr/sim/avr_timer.c
modified:   ../../simavr/sim/avr_timer.h
```
