### PR TITLE
avr_timer: rework timer comparator cycle timers.

### DIFF
--- a/simavr/sim/avr_timer.h
+++ b/simavr/sim/avr_timer.h
@@ -91,6 +91,8 @@ typedef struct avr_timer_wgm_t {
 typedef struct avr_timer_comp_t {
 		avr_int_vector_t	interrupt;		// interrupt vector
 		struct avr_timer_t	*timer;			// parent timer
+		struct avr_irq_t	*irq;			// parent timer comparator io->irq
+		avr_cycle_timer_t	handler;		// comparator timer handler
 		avr_io_addr_t		r_ocr;			// comparator register low byte
 		avr_io_addr_t		r_ocrh;			// comparator register hi byte
 		avr_regbit_t		com;			// comparator output mode registers


### PR DESCRIPTION
timer comparator handlers have been reworked to use pointer to
 comparator structure as parameter from cycle timer.  as part, all
 timer cancel operations have changed to single function to handle
 the cancel of timers based on pointer to comparator structure as
 parameter.

```
modified:   ../../simavr/sim/avr_timer.c
modified:   ../../simavr/sim/avr_timer.h
```
