### PR TITLE
Add some commands to the GDB stub

### DIFF
--- a/simavr/sim/sim_gdb.c
+++ b/simavr/sim/sim_gdb.c
@@ -288,7 +288,14 @@ gdb_handle_command(
 	uint8_t command = *cmd++;
 	switch (command) {
 		case 'q':
-			if (strncmp(cmd, "Attached", 8) == 0) {
+			if (strncmp(cmd, "Supported", 9) == 0) {
+				/* If GDB asked what features we support, report back
+				 * the features we support, which is just memory layout
+				 * information for now.
+				 */
+				gdb_send_reply(g, "qXfer:memory-map:read+");
+				break;
+			} else if (strncmp(cmd, "Attached", 8) == 0) {
 				/* Respond that we are attached to an existing process..
 				 * ourselves!
 				 */
@@ -297,6 +304,19 @@ gdb_handle_command(
 			} else if (strncmp(cmd, "Offsets", 7) == 0) {
 				gdb_send_reply(g, "Text=0;Data=800000;Bss=800000");
 				break;
+			} else if (strncmp(cmd, "Xfer:memory-map:read", 20) == 0) {
+				snprintf(rep, sizeof(rep),
+						"l<memory-map>\n"
+						" <memory type='ram' start='0x800000' length='%#x'/>\n"
+						" <memory type='flash' start='0' length='%#x'>\n"
+						"  <property name='blocksize'>0x80</property>\n"
+						" </memory>\n"
+						"</memory-map>",
+						g->avr->ramend + 1, g->avr->flashend + 1);
+
+				gdb_send_reply(g, rep);
+				break;
+            }
 			gdb_send_reply(g, "");
 			break;
 		case '?':


### PR DESCRIPTION
I've got all IAR built binaries and have been hoping to try to figure out a way to convert the C-Spy files (UBROF file format with .d90 extension) to something that I can work with in GDB or getting IAR Embedded Workbench to talk to a GDB stub but alas no luck. But I did learn a little bit of GDB stub/serial protocol bits and implemented some commands I noticed that my copy of avr-gdb requested but we reported as unsupported.
