### PR TITLE
sim_core: fix rcall instruction cycles...

### DIFF
--- a/simavr/sim/sim_core.c
+++ b/simavr/sim/sim_core.c
@@ -1360,7 +1360,7 @@ avr_flashaddr_t avr_run_one(avr_t * avr)
 		case 0xd000: {	// RCALL -- 1101 kkkk kkkk kkkk
 			get_o_12(opcode);
 			STATE("rcall .%d [%04x]\n", o, new_pc + (o << 1));
-			cycle += _avr_push_addr(avr, new_pc) - 1;
+			cycle += _avr_push_addr(avr, new_pc);
 			new_pc = new_pc + (o << 1);
 			// 'rcall .1' is used as a cheap "push 16 bits of room on the stack"
 			if (o != 0) {


### PR DESCRIPTION
Based on the instrtiming.elf code and checking the Avr Instruction
 Manual, RCALL was found to be producing incorrect cycle counts.

Atmega; 3, 16-bit pc; 4, 22-bit pc.

Fixed accordingly.

```
modified:   sim/sim_core.c
```
