### PR TITLE
flash: Add support for TEMPPAGE writing.

### DIFF
--- a/simavr/sim/avr_flash.h
+++ b/simavr/sim/avr_flash.h
@@ -37,6 +37,8 @@ typedef struct avr_flash_t {
 	avr_io_t	io;
 
 	uint16_t	flags;
+	uint16_t	*tmppage;
+	uint8_t	*tmppage_used;
 	uint16_t	spm_pagesize;
 	uint8_t r_spm;
 	avr_regbit_t selfprgen;


### PR DESCRIPTION
The proper way to write to flash on the AVR is to write
to the temp page and then write that temp page to flash.
This allows cancellation with the RWWSRE bit for clearing
out the temp page without writing it to flash.

This fixed a bug where the RWWSRE bit was being set in a
command, but the flash driver was improperly writing whatever
was in r0/r1 to the first address in the page, overwriting
what was already there. In reality, the code running on the
core was trying to just flush the temp page or unlock the read
while write section.
