### PR TITLE
cores: Fix PCINT8 for ATmega128RFA1 and ATmega128RFR2

### DIFF
--- a/simavr/cores/sim_mega128rfa1.c
+++ b/simavr/cores/sim_mega128rfa1.c
@@ -93,6 +93,12 @@ const struct mcu_t {
 	},
 	.porte = {
 		.name = 'E', .r_port = PORTE, .r_ddr = DDRE, .r_pin = PINE,
+		.pcint = {
+			.enable = AVR_IO_REGBIT(PCICR, PCIE1),
+			.raised = AVR_IO_REGBIT(PCIFR, PCIF1),
+			.vector = PCINT1_vect,
+		},
+		.r_pcint = PCMSK1,
 	},
 	.portf = {
 		.name = 'F', .r_port = PORTF, .r_ddr = DDRF, .r_pin = PINF,

--- a/simavr/cores/sim_mega128rfr2.c
+++ b/simavr/cores/sim_mega128rfr2.c
@@ -93,6 +93,12 @@ const struct mcu_t {
 	},
 	.porte = {
 		.name = 'E', .r_port = PORTE, .r_ddr = DDRE, .r_pin = PINE,
+		.pcint = {
+			.enable = AVR_IO_REGBIT(PCICR, PCIE1),
+			.raised = AVR_IO_REGBIT(PCIFR, PCIF1),
+			.vector = PCINT1_vect,
+		},
+		.r_pcint = PCMSK1,
 	},
 	.portf = {
 		.name = 'F', .r_port = PORTF, .r_ddr = DDRF, .r_pin = PINF,


### PR DESCRIPTION
PCINT8 was previously not setup. Per the spec sheet it is on Port E pin
0.
