### PR TITLE
Cycle counters

### DIFF
--- a/doc/manual/simavr.tex
+++ b/doc/manual/simavr.tex
@@ -295,7 +295,7 @@ delay of one instruction.
 
 \begin{lstlisting}
     avr_cycle_count_t sleep = avr_cycle_timer_process(avr);
-    avr->pc = new_pc;
+    avr_set_pc(avr, new_pc);
 \end{lstlisting}
 
 Next, all due cycle timers are processed. Cycle timers are one of the

--- a/simavr/sim/avr/avr_mcu_section.h
+++ b/simavr/sim/avr/avr_mcu_section.h
@@ -212,6 +212,73 @@ struct avr_mmcu_vcd_trace_t {
 	AVR_MCU_STRING(AVR_MMCU_TAG_NAME, _name);\
 	AVR_MCU_LONG(AVR_MMCU_TAG_FREQUENCY, _speed)
 
+/*
+ * The following MAP macros where copied from
+ * https://github.com/swansontec/map-macro/blob/master/map.h
+ *
+ * The license header for that file is reproduced below:
+ *
+ * Copyright (C) 2012 William Swanson
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Except as contained in this notice, the names of the authors or
+ * their institutions shall not be used in advertising or otherwise to
+ * promote the sale, use or other dealings in this Software without
+ * prior written authorization from the authors.
+ */
+
+#define _EVAL0(...) __VA_ARGS__
+#define _EVAL1(...) _EVAL0 (_EVAL0 (_EVAL0 (__VA_ARGS__)))
+#define _EVAL2(...) _EVAL1 (_EVAL1 (_EVAL1 (__VA_ARGS__)))
+#define _EVAL3(...) _EVAL2 (_EVAL2 (_EVAL2 (__VA_ARGS__)))
+#define _EVAL4(...) _EVAL3 (_EVAL3 (_EVAL3 (__VA_ARGS__)))
+#define _EVAL(...)  _EVAL4 (_EVAL4 (_EVAL4 (__VA_ARGS__)))
+
+#define _MAP_END(...)
+#define _MAP_OUT
+
+#define _MAP_GET_END() 0, _MAP_END
+#define _MAP_NEXT0(test, next, ...) next _MAP_OUT
+#define _MAP_NEXT1(test, next) _MAP_NEXT0 (test, next, 0)
+#define _MAP_NEXT(test, next)  _MAP_NEXT1 (_MAP_GET_END test, next)
+
+#define _MAP0(f, x, peek, ...) f(x) _MAP_NEXT (peek, _MAP1) (f, peek, __VA_ARGS__)
+#define _MAP1(f, x, peek, ...) f(x) _MAP_NEXT (peek, _MAP0) (f, peek, __VA_ARGS__)
+#define _MAP(f, ...) _EVAL (-MAP1 (f, __VA_ARGS__, (), 0))
+
+/* End of original MAP macros. */
+
+// Define MAP macros with one additional argument
+#define _MAP0_1(f, a, x, peek, ...) f(a, x) _MAP_NEXT (peek, _MAP1_1) (f, a, peek, __VA_ARGS__)
+#define _MAP1_1(f, a, x, peek, ...) f(a, x) _MAP_NEXT (peek, _MAP0_1) (f, a, peek, __VA_ARGS__)
+#define _MAP_1(f, a, ...) _EVAL (_MAP1_1 (f, a, __VA_ARGS__, (), 0))
+
+#define _SEND_SIMAVR_CMD_BYTE(reg, b)            reg = b;
+
+// A helper macro for sending multi-byte commands
+#define SEND_SIMAVR_CMD(reg, ...)		\
+	do { \
+		_MAP_1(_SEND_SIMAVR_CMD_BYTE, reg, __VA_ARGS__) \
+	} while(0)
+
 #endif /* __AVR__ */
 
 #ifdef __cplusplus

--- a/simavr/sim/avr/avr_mcu_section.h
+++ b/simavr/sim/avr/avr_mcu_section.h
@@ -61,6 +61,7 @@ enum {
 	AVR_MMCU_TAG_VCD_PERIOD,
 	AVR_MMCU_TAG_VCD_TRACE,
 	AVR_MMCU_TAG_PORT_EXTERNAL_PULL,
+	AVR_MMCU_TAG_CYCLE_COUNTER
 };
 
 enum {
@@ -68,6 +69,8 @@ enum {
 	SIMAVR_CMD_VCD_START_TRACE,
 	SIMAVR_CMD_VCD_STOP_TRACE,
 	SIMAVR_CMD_UART_LOOPBACK,
+	SIMAVR_CMD_START_CYCLE_COUNTER,
+	SIMAVR_CMD_STOP_CYCLE_COUNTER,
 };
 
 #if __AVR__
@@ -96,6 +99,13 @@ struct avr_mmcu_vcd_trace_t {
 	uint8_t len;
 	uint8_t mask;
 	void * what;
+	char name[];
+} __attribute__((__packed__));
+
+struct avr_mmcu_cycle_counter_t {
+	uint8_t tag;
+	uint8_t len;
+	uint8_t id;
 	char name[];
 } __attribute__((__packed__));
 
@@ -139,6 +149,26 @@ struct avr_mmcu_vcd_trace_t {
 #define AVR_MCU_VCD_SYMBOL(_name) \
 	.tag = AVR_MMCU_TAG_VCD_TRACE, \
 	.len = sizeof(struct avr_mmcu_vcd_trace_t) - 2 + sizeof(_name),\
+	.name = _name
+
+/*!
+ * Allows you to define named cycle counters.
+ *
+ * Example:
+ * 	enum {
+ * 		COUNTER_1,
+ * 		COUNTER_2,
+ * 	};
+ *
+ * 	const struct avr_mmcu_cycle_counter_t _cycle_counters _MMCU_ = {
+ * 		{ AVR_MCU_CYCLE_COUNTER(COUNTER_1, "Counter 1") },
+ * 		{ AVR_MCU_CYCLE_COUNTER(COUNTER_2, "Counter 2") },
+ * 	};
+ */
+#define AVR_MCU_CYCLE_COUNTER(_id, _name) \
+	.tag = AVR_MMCU_TAG_CYCLE_COUNTER, \
+	.len = sizeof(struct avr_mmcu_cycle_counter_t) - 2 + sizeof(_name),\
+	.id = _id, \
 	.name = _name
 
 /*!

--- a/simavr/sim/avr/avr_mcu_section.h
+++ b/simavr/sim/avr/avr_mcu_section.h
@@ -71,6 +71,7 @@ enum {
 	SIMAVR_CMD_UART_LOOPBACK,
 	SIMAVR_CMD_START_CYCLE_COUNTER,
 	SIMAVR_CMD_STOP_CYCLE_COUNTER,
+	SIMAVR_CMD_USER,	// Denotes start of user-defined commands
 };
 
 #if __AVR__

--- a/simavr/sim/sim_avr.c
+++ b/simavr/sim/sim_avr.c
@@ -124,7 +124,7 @@ void avr_reset(avr_t * avr)
 
 	memset(avr->data, 0x0, avr->ramend + 1);
 	_avr_sp_set(avr, avr->ramend);
-	avr->pc = 0;
+	avr->old_pc = avr->pc = 0;
 	for (int i = 0; i < 8; i++)
 		avr->sreg[i] = 0;
 	avr_interrupt_reset(avr);
@@ -180,6 +180,12 @@ void avr_set_console_register(avr_t * avr, avr_io_addr_t addr)
 {
 	if (addr)
 		avr_register_io_write(avr, addr, _avr_io_console_write, NULL);
+}
+
+void avr_set_pc(avr_t * avr, avr_flashaddr_t new_pc)
+{
+	avr->old_pc = avr->pc;
+	avr->pc = new_pc;
 }
 
 void avr_loadcode(avr_t * avr, uint8_t * code, uint32_t size, avr_flashaddr_t address)
@@ -249,7 +255,7 @@ void avr_callback_run_gdb(avr_t * avr)
 	// until the next timer is due
 	avr_cycle_count_t sleep = avr_cycle_timer_process(avr);
 
-	avr->pc = new_pc;
+	avr_set_pc(avr, new_pc);
 
 	if (avr->state == cpu_Sleeping) {
 		if (!avr->sreg[S_I]) {
@@ -303,7 +309,7 @@ void avr_callback_run_raw(avr_t * avr)
 	// until the next timer is due
 	avr_cycle_count_t sleep = avr_cycle_timer_process(avr);
 
-	avr->pc = new_pc;
+	avr_set_pc(avr, new_pc);
 
 	if (avr->state == cpu_Sleeping) {
 		if (!avr->sreg[S_I]) {

--- a/simavr/sim/sim_avr.c
+++ b/simavr/sim/sim_avr.c
@@ -83,6 +83,7 @@ int avr_init(avr_t * avr)
 	avr->state = cpu_Limbo;
 	avr->frequency = 1000000;	// can be overridden via avr_mcu_section
 	avr_cmd_init(avr);
+	avr_cycle_counter_init(avr);
 	avr_interrupt_init(avr);
 	if (avr->special_init)
 		avr->special_init(avr, avr->special_data);

--- a/simavr/sim/sim_avr.h
+++ b/simavr/sim/sim_avr.h
@@ -393,10 +393,10 @@ avr_sadly_crashed(
  */
 void
 avr_global_logger(
-		struct avr_t* avr, 
-		const int level, 
-		const char * format, 
-		... );
+		struct avr_t* avr,
+		const int level,
+		const char * format,
+		... ) __attribute__((format(printf, 3, 4)));
 
 #ifndef AVR_CORE
 #include <stdarg.h>

--- a/simavr/sim/sim_avr.h
+++ b/simavr/sim/sim_avr.h
@@ -30,6 +30,7 @@ extern "C" {
 #include "sim_interrupts.h"
 #include "sim_cmds.h"
 #include "sim_cycle_timers.h"
+#include "sim_cycle_counters.h"
 
 typedef uint32_t avr_flashaddr_t;
 
@@ -270,6 +271,8 @@ typedef struct avr_t {
 	avr_cmd_table_t commands;
 	// cycle timers tracking & delivery
 	avr_cycle_timer_pool_t	cycle_timers;
+	// cycle counter registry
+	avr_cycle_counter_pool_t cycle_counters;
 	// interrupt vectors and delivery fifo
 	avr_int_table_t	interrupts;
 

--- a/simavr/sim/sim_avr.h
+++ b/simavr/sim/sim_avr.h
@@ -28,6 +28,7 @@ extern "C" {
 
 #include "sim_irq.h"
 #include "sim_interrupts.h"
+#include "sim_cmds.h"
 #include "sim_cycle_timers.h"
 
 typedef uint32_t avr_flashaddr_t;
@@ -263,6 +264,8 @@ typedef struct avr_t {
 	// queue of io modules
 	struct avr_io_t *io_port;
 
+	// Builtin and user-defined commands
+	avr_cmd_table_t commands;
 	// cycle timers tracking & delivery
 	avr_cycle_timer_pool_t	cycle_timers;
 	// interrupt vectors and delivery fifo

--- a/simavr/sim/sim_avr.h
+++ b/simavr/sim/sim_avr.h
@@ -216,6 +216,8 @@ typedef struct avr_t {
 	 * It CAN be a little confusing, so concentrate, young grasshopper.
 	 */
 	avr_flashaddr_t	pc;
+	// Previous PC - needed for cycle counter overhead accounting.
+	avr_flashaddr_t	old_pc;
 
 	/*
 	 * callback when specific IO registers are read/written.
@@ -347,6 +349,11 @@ void
 avr_set_console_register(
 		avr_t * avr,
 		avr_io_addr_t addr);
+
+void
+avr_set_pc(
+		avr_t * avr,
+		avr_flashaddr_t new_pc);
 
 // load code in the "flash"
 void

--- a/simavr/sim/sim_cmds.c
+++ b/simavr/sim/sim_cmds.c
@@ -19,16 +19,23 @@
 	along with simavr.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 #include "sim_avr.h"
+#include "sim_cycle_counters.h"
 #include "sim_cmds.h"
 #include "sim_vcd_file.h"
 #include "avr_uart.h"
 #include "avr/avr_mcu_section.h"
 
 #define LOG_PREFIX		"CMDS: "
+
+// Internal struct for simple multi-byte commands with no further state
+typedef struct avr_cmd_multibyte_ctx_t {
+	int byte;
+	avr_cycle_count_t overhead;
+} avr_cmd_multibyte_ctx_t;
 
 static void
 _avr_cmd_io_write(
@@ -165,14 +172,98 @@ _simavr_cmd_uart_loopback(
 	return 0;
 }
 
+static avr_cycle_count_t
+_avr_cmd_calculate_overhead(
+		avr_t * avr)
+{
+	/*
+	 * The overhead is calculated by examining the current and previous
+	 * instructions, making a few assumptions:
+	 *
+	 * - The current instruction has to be 'out' and consumes one clock cycle.
+	 *   Because of this, overhead is initialized to 1.
+	 * - To write to an IO address, the value has to be first loaded into a
+	 *   register using 'ldi' or by clearing the register using 'eor'.
+	 * - If the value isn't loaded immediately in the instruction before, the
+	 *   value has already been placed into the register as part of the regular
+	 *   program flow and is not considered overhead.
+	 *
+	 * Any compiler or hand-written code can of course easily violate these
+	 * assumptions and break the overhead accounting. You have been warned.
+	 */
+	uint8_t out_r;
+	uint32_t opcode;
+	avr_cycle_count_t overhead = 1;
+
+	opcode = (avr->flash[avr->pc + 1] << 8) | avr->flash[avr->pc];
+	assert((opcode & 0xf800) == 0xb800);
+	out_r = (opcode >> 4) & 0x1f;
+
+	opcode = (avr->flash[avr->old_pc + 1] << 8) | avr->flash[avr->old_pc];
+	// 'ldi'
+	if((opcode & 0xf000) == 0xe000 && (16 + ((opcode >> 4) & 0xf) == out_r))
+		++overhead;
+	// 'eor'
+	else if((opcode & 0xfc00) == 0x2400
+			&& (((opcode >> 5) & 0x10) | (opcode & 0xf)) == out_r
+			&& ((opcode >> 4) & 0x1f) == out_r)
+		++overhead;
+
+	return overhead;
+}
+
+static int
+_simavr_cmd_start_cycle_counter(
+		avr_t * avr,
+		uint8_t v,
+		void * param)
+{
+	avr_cmd_multibyte_ctx_t * ctx = (avr_cmd_multibyte_ctx_t *)param;
+
+	if(ctx->byte == 0) {
+		ctx->overhead += _avr_cmd_calculate_overhead(avr);
+		++ctx->byte;
+	}
+	else if(ctx->byte == 1) {
+		ctx->overhead += _avr_cmd_calculate_overhead(avr);
+
+		avr_cycle_counter_start_with_overhead(avr, v, ctx->overhead);
+
+		ctx->overhead = 0;
+		ctx->byte = 0;
+	}
+
+	return ctx->byte;
+}
+
+static int
+_simavr_cmd_stop_cycle_counter(
+		avr_t * avr,
+		uint8_t v,
+		void * param)
+{
+	avr_cycle_count_t overhead = _avr_cmd_calculate_overhead(avr);
+
+	avr_cycle_counter_stop_with_overhead(avr, overhead);
+
+	return 0;
+}
+
 void
 avr_cmd_init(
 		avr_t * avr)
 {
+	avr_cmd_multibyte_ctx_t * cycle_counter_ctx;
+
 	memset(&avr->commands, 0, sizeof(avr->commands));
+
+	cycle_counter_ctx = malloc(sizeof(*cycle_counter_ctx));
+	memset(cycle_counter_ctx, 0, sizeof(*cycle_counter_ctx));
 
 	// Register builtin commands
 	avr_cmd_register(avr, SIMAVR_CMD_VCD_START_TRACE, &_simavr_cmd_vcd_start_trace, NULL);
 	avr_cmd_register(avr, SIMAVR_CMD_VCD_STOP_TRACE, &_simavr_cmd_vcd_stop_trace, NULL);
 	avr_cmd_register(avr, SIMAVR_CMD_UART_LOOPBACK, &_simavr_cmd_uart_loopback, NULL);
+	avr_cmd_register(avr, SIMAVR_CMD_START_CYCLE_COUNTER, &_simavr_cmd_start_cycle_counter, cycle_counter_ctx);
+	avr_cmd_register(avr, SIMAVR_CMD_STOP_CYCLE_COUNTER, &_simavr_cmd_stop_cycle_counter, NULL);
 }

--- a/simavr/sim/sim_cmds.c
+++ b/simavr/sim/sim_cmds.c
@@ -1,0 +1,178 @@
+/*
+	sim_cmds.c
+
+	Copyright 2014 Florian Albrechtskirchinger <falbrechtskirchinger@gmail.com>
+
+	This file is part of simavr.
+
+	simavr is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	simavr is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with simavr.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include <stdlib.h>
+#include <string.h>
+#include "sim_avr.h"
+#include "sim_cmds.h"
+#include "sim_vcd_file.h"
+#include "avr_uart.h"
+#include "avr/avr_mcu_section.h"
+
+#define LOG_PREFIX		"CMDS: "
+
+static void
+_avr_cmd_io_write(
+		avr_t * avr,
+		avr_io_addr_t addr,
+		uint8_t v,
+		void * param)
+{
+	avr_cmd_table_t * commands = &avr->commands;
+	avr_cmd_t * command = commands->pending;
+
+	AVR_LOG(avr, LOG_TRACE, LOG_PREFIX "%s: 0x%02x\n", __FUNCTION__, v);
+
+	if(!command) {
+		if(v > MAX_AVR_COMMANDS) {
+			AVR_LOG(avr, LOG_ERROR, LOG_PREFIX "%s: code 0x%02x outside permissible range (>0x%02x)\n", __FUNCTION__, v, MAX_AVR_COMMANDS - 1);
+			return;
+		}
+
+		command = &commands->table[v];
+	}
+
+	if(command) {
+		if(command->handler(avr, v, command->param))
+			commands->pending = command;
+		else
+			commands->pending = NULL;
+	}
+	else
+		AVR_LOG(avr, LOG_TRACE, LOG_PREFIX "%s: unknown command 0x%02x\n", __FUNCTION__, v);
+}
+
+void
+avr_cmd_set_register(
+		avr_t * avr,
+		avr_io_addr_t addr)
+{
+	if(addr)
+		avr_register_io_write(avr, addr, &_avr_cmd_io_write, NULL);
+}
+
+void
+avr_cmd_register(
+		avr_t * avr,
+		uint8_t code,
+		avr_cmd_handler_t handler,
+		void * param)
+{
+	avr_cmd_table_t * commands = &avr->commands;
+	avr_cmd_t * command;
+
+	if(!handler)
+		return;
+
+	if(code > MAX_AVR_COMMANDS) {
+		AVR_LOG(avr, LOG_ERROR, LOG_PREFIX "%s: code 0x%02x outside permissible range (>0x%02x)\n", __FUNCTION__, code, MAX_AVR_COMMANDS - 1);
+		return;
+	}
+
+	command = &commands->table[code];
+	if(command->handler) {
+		AVR_LOG(avr, LOG_ERROR, LOG_PREFIX "%s: code 0x%02x is already registered\n", __FUNCTION__, code);
+		return;
+	}
+
+	command->handler = handler;
+	command->param = param;
+}
+
+void
+avr_cmd_unregister(
+		avr_t * avr,
+		uint8_t code)
+{
+	avr_cmd_table_t * commands = &avr->commands;
+	avr_cmd_t * command;
+
+	if(code > MAX_AVR_COMMANDS) {
+		AVR_LOG(avr, LOG_ERROR, LOG_PREFIX "%s: code 0x%02x outside permissible range (>0x%02x)\n", __FUNCTION__, code, MAX_AVR_COMMANDS - 1);
+		return;
+	}
+
+	command = &commands->table[code];
+	if(command->handler) {
+		if(command->param)
+			free(command->param);
+
+		command->handler = NULL;
+		command->param = NULL;
+	}
+	else
+		AVR_LOG(avr, LOG_ERROR, LOG_PREFIX "%s: no command registered for code 0x%02x\n", __FUNCTION__, code);
+}
+
+static int
+_simavr_cmd_vcd_start_trace(
+		avr_t * avr,
+		uint8_t v,
+		void * param)
+{
+	if(avr->vcd)
+		avr_vcd_start(avr->vcd);
+
+	return 0;
+}
+
+static int
+_simavr_cmd_vcd_stop_trace(
+		avr_t * avr,
+		uint8_t v,
+		void * param)
+{
+	if(avr->vcd)
+		avr_vcd_stop(avr->vcd);
+
+	return 0;
+}
+
+static int
+_simavr_cmd_uart_loopback(
+		avr_t * avr,
+		uint8_t v,
+		void * param)
+{
+	avr_irq_t * src = avr_io_getirq(avr, AVR_IOCTL_UART_GETIRQ('0'), UART_IRQ_OUTPUT);
+	avr_irq_t * dst = avr_io_getirq(avr, AVR_IOCTL_UART_GETIRQ('0'), UART_IRQ_INPUT);
+
+	if(src && dst) {
+		AVR_LOG(avr, LOG_TRACE, LOG_PREFIX "%s: activating uart local echo; IRQ src %p dst %p\n",
+				__FUNCTION__, src, dst);
+		avr_connect_irq(src, dst);
+	}
+
+	return 0;
+}
+
+void
+avr_cmd_init(
+		avr_t * avr)
+{
+	memset(&avr->commands, 0, sizeof(avr->commands));
+
+	// Register builtin commands
+	avr_cmd_register(avr, SIMAVR_CMD_VCD_START_TRACE, &_simavr_cmd_vcd_start_trace, NULL);
+	avr_cmd_register(avr, SIMAVR_CMD_VCD_STOP_TRACE, &_simavr_cmd_vcd_stop_trace, NULL);
+	avr_cmd_register(avr, SIMAVR_CMD_UART_LOOPBACK, &_simavr_cmd_uart_loopback, NULL);
+}

--- a/simavr/sim/sim_cmds.h
+++ b/simavr/sim/sim_cmds.h
@@ -1,0 +1,82 @@
+/*
+	sim_cmds.h
+
+	Copyright 2014 Florian Albrechtskirchinger <falbrechtskirchinger@gmail.com>
+
+	This file is part of simavr.
+
+	simavr is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	simavr is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with simavr.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "sim_avr_types.h"
+
+#define MAX_AVR_COMMANDS		32
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef int (*avr_cmd_handler_t)(
+		struct avr_t * avr,
+		uint8_t v,
+		void * param);
+
+typedef struct avr_cmd_t {
+	avr_cmd_handler_t handler;
+	void * param;
+} avr_cmd_t;
+
+typedef struct avr_cmd_table_t {
+	avr_cmd_t table[MAX_AVR_COMMANDS];
+	avr_cmd_t * pending;	// Holdes a reference to a pending multi-byte command
+} avr_cmd_table_t;
+
+// Called by avr_set_command_register()
+void
+avr_cmd_set_register(
+		struct avr_t * avr,
+		avr_io_addr_t addr);
+
+/*
+ * Register a command distinguished by 'code'.
+ *
+ * When 'code' is written to the configured IO address, 'handler' is executed
+ * with the value written, as well as 'param'.
+ * 'handler' can return non-zero, to indicate, that this is a multi-byte command.
+ * Subsequent writes are then dispatched to the same handler, until 0 is returned.
+ */
+void
+avr_cmd_register(
+		struct avr_t * avr,
+		uint8_t code,
+		avr_cmd_handler_t handler,
+		void * param);
+
+void
+avr_cmd_unregister(
+		struct avr_t * avr,
+		uint8_t code);
+
+// Private functions
+
+// Called from avr_init() to initialize the avr_cmd_table_t and register builtin commands.
+void
+avr_cmd_init(
+		struct avr_t * avr);
+
+#ifdef __cplusplus
+}
+#endif

--- a/simavr/sim/sim_cycle_counters.c
+++ b/simavr/sim/sim_cycle_counters.c
@@ -1,0 +1,258 @@
+/*
+	sim_cycle_counters.c
+
+	Copyright 2014 Florian Albrechtskirchinger <falbrechtskirchinger@gmail.com>
+
+	This file is part of simavr.
+
+	simavr is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	simavr is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with simavr.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "sim_avr.h"
+#include "sim_time.h"
+#include "sim_cycle_counters.h"
+
+#define LOG_PREFIX		"CYCLE_COUNTERS: "
+
+// Internal struct for the notify callbacks
+typedef struct avr_cycle_counter_hook_t {
+	struct avr_cycle_counter_hook_t * next;
+	avr_cycle_counter_notify_t notify;
+	void * param;
+} avr_cycle_counter_hook_t;
+
+void
+avr_cycle_counter_init(
+		avr_t * avr)
+{
+	memset(&avr->cycle_counters, 0, sizeof(avr->cycle_counters));
+}
+
+void
+avr_cycle_counter_register(
+		avr_t * avr,
+		uint8_t id,
+		const char * name)
+{
+	avr_cycle_counter_pool_t * pool = &avr->cycle_counters;
+	avr_cycle_counter_t * counter;
+
+	if(id >= MAX_CYCLE_COUNTERS) {
+		AVR_LOG(avr, LOG_ERROR, LOG_PREFIX "%s: id 0x%02x outside permissible range (>0x%02x)\n", __FUNCTION__, id, MAX_CYCLE_COUNTERS - 1);
+		return;
+	}
+
+	counter = &pool->counters[id];
+	if(counter->registered) {
+		AVR_LOG(avr, LOG_ERROR, LOG_PREFIX "%s: counter with ID %d ('%s') already registered\n", __FUNCTION__, id, counter->name);
+		return;
+	}
+
+	AVR_LOG(avr, LOG_TRACE, LOG_PREFIX "%s: register cycle counter '%s' (%d)\n", __FUNCTION__, name, id);
+
+	memset(counter, 0, sizeof(*counter));
+	if(name) {
+		strncpy(counter->name, name, sizeof(counter->name));
+		counter->name[sizeof(counter->name) - 1] = 0;
+	}
+
+	counter->registered = 1;
+}
+
+void
+avr_cycle_counter_unregister(
+		avr_t * avr,
+		uint8_t id)
+{
+	avr_cycle_counter_pool_t * pool = &avr->cycle_counters;
+	avr_cycle_counter_t * counter;
+
+	if(id >= MAX_CYCLE_COUNTERS) {
+		AVR_LOG(avr, LOG_ERROR, LOG_PREFIX "%s: id 0x%02x outside permissible range (>0x%02x)\n", __FUNCTION__, id, MAX_CYCLE_COUNTERS - 1);
+		return;
+	}
+
+	counter = &pool->counters[id];
+	if(!counter->registered) {
+		AVR_LOG(avr, LOG_ERROR, LOG_PREFIX "%s: no counter with ID %d registered\n", __FUNCTION__, id);
+		return;
+	}
+
+	AVR_LOG(avr, LOG_TRACE, LOG_PREFIX "%s: unregister cycle counter '%s' (%d)\n", __FUNCTION__, counter->name, id);
+
+	counter->registered = 0;
+}
+
+static void
+_avr_cycle_counter_start(
+		avr_t * avr,
+		uint8_t id,
+		avr_cycle_count_t overhead)
+{
+	avr_cycle_counter_pool_t * pool = &avr->cycle_counters;
+	avr_cycle_counter_t * counter;
+
+	if(id >= MAX_CYCLE_COUNTERS) {
+		AVR_LOG(avr, LOG_ERROR, LOG_PREFIX "%s: id 0x%02x outside permissible range (>0x%02x)\n", __FUNCTION__, id, MAX_CYCLE_COUNTERS - 1);
+		return;
+	}
+
+	counter = &pool->counters[id];
+	if(!counter->registered) {
+		AVR_LOG(avr, LOG_ERROR, LOG_PREFIX "%s: counter with id %d not registered\n", __FUNCTION__, id);
+		return;
+	}
+
+	counter->start = avr->cycle;
+	// The overhead for this counter only consist of 1 'out'
+	counter->overhead = overhead ? 1 : 0;
+
+	// Append the counter to the list of active counters
+	counter->prev = pool->counter_tail;
+	pool->counter_tail = counter;
+
+	// Propagate the overhead through the list of active counters
+	counter = counter->prev;
+	while(overhead && counter) {
+		counter->overhead += overhead;
+
+		counter = counter->prev;
+	}
+}
+
+void
+avr_cycle_counter_start(
+		avr_t * avr,
+		uint8_t id)
+{
+	_avr_cycle_counter_start(avr, id, 0);
+}
+
+void
+avr_cycle_counter_start_with_overhead(
+		avr_t * avr,
+		uint8_t id,
+		avr_cycle_count_t overhead)
+{
+	_avr_cycle_counter_start(avr, id, overhead);
+}
+
+static void
+_avr_cycle_counter_stop(
+		avr_t * avr,
+		avr_cycle_count_t overhead)
+{
+	avr_cycle_count_t cycles;
+	avr_cycle_counter_pool_t * pool = &avr->cycle_counters;
+	avr_cycle_counter_t * counter = pool->counter_tail;
+	avr_cycle_counter_hook_t * hook = pool->hook;
+
+	if(!counter) {
+		AVR_LOG(avr, LOG_ERROR, LOG_PREFIX "%s: no counters are currently active\n", __FUNCTION__);
+		return;
+	}
+
+	cycles = avr->cycle - counter->start - counter->overhead;
+
+	AVR_LOG(avr, LOG_TRACE, LOG_PREFIX "%s: counter '%s' measured %" PRI_avr_cycle_count " cycle(s)\n", __FUNCTION__, counter->name, cycles);
+
+	// Invoke callbacks
+	while(hook) {
+		if(hook->notify)
+			hook->notify(avr, counter, cycles, hook->param);
+
+		hook = hook->next;
+	}
+
+	// Remove the counter from the list of active counters
+	pool->counter_tail = counter = counter->prev;
+
+	// Propagate the overhead through the list of active counter
+	while(overhead && counter) {
+		counter->overhead += overhead;
+
+		counter = counter->prev;
+	}
+}
+
+void
+avr_cycle_counter_stop(
+		avr_t * avr)
+{
+	_avr_cycle_counter_stop(avr, 0);
+}
+
+void
+avr_cycle_counter_stop_with_overhead(
+		avr_t * avr,
+		avr_cycle_count_t overhead)
+{
+	_avr_cycle_counter_stop(avr, overhead);
+}
+
+void
+avr_cycle_counter_register_notify(
+		avr_t * avr,
+		avr_cycle_counter_notify_t notify,
+		void * param)
+{
+	avr_cycle_counter_pool_t * pool = &avr->cycle_counters;
+	avr_cycle_counter_hook_t * hook;
+
+	if(!notify)
+		return;
+
+	hook = malloc(sizeof(*hook));
+
+	hook->notify = notify;
+	hook->param = param;
+
+	hook->next = pool->hook;
+	pool->hook = hook;
+}
+
+void
+avr_cycle_counter_unregister_notify(
+		avr_t * avr,
+		avr_cycle_counter_notify_t notify,
+		void * param)
+{
+	avr_cycle_counter_pool_t * pool = &avr->cycle_counters;
+	avr_cycle_counter_hook_t * hook, * prev = NULL;
+
+	if(!notify)
+		return;
+
+	hook = pool->hook;
+	while(hook) {
+		if(hook->notify == notify && hook->param == param) {
+			if(prev)
+				prev->next = hook->next;
+			else
+				pool->hook = hook->next;
+
+			free(hook);
+
+			return;
+		}
+
+		prev = hook;
+		hook = hook->next;
+	}
+
+	AVR_LOG(avr, LOG_ERROR, LOG_PREFIX "%s: cannot unregister non-existent counter notify\n", __FUNCTION__);
+}

--- a/simavr/sim/sim_cycle_counters.c
+++ b/simavr/sim/sim_cycle_counters.c
@@ -65,6 +65,7 @@ avr_cycle_counter_register(
 	AVR_LOG(avr, LOG_TRACE, LOG_PREFIX "%s: register cycle counter '%s' (%d)\n", __FUNCTION__, name, id);
 
 	memset(counter, 0, sizeof(*counter));
+	counter->id = id;
 	if(name) {
 		strncpy(counter->name, name, sizeof(counter->name));
 		counter->name[sizeof(counter->name) - 1] = 0;
@@ -168,7 +169,7 @@ _avr_cycle_counter_stop(
 
 	cycles = avr->cycle - counter->start - counter->overhead;
 
-	AVR_LOG(avr, LOG_TRACE, LOG_PREFIX "%s: counter '%s' measured %" PRI_avr_cycle_count " cycle(s) (overhead %" PRI_avr_cycle_count " cycle(s))\n", __FUNCTION__, counter->name, cycles, counter->overhead);
+	AVR_LOG(avr, LOG_TRACE, LOG_PREFIX "%s: counter '%s' (%d) measured %" PRI_avr_cycle_count " cycle(s) (overhead %" PRI_avr_cycle_count " cycle(s))\n", __FUNCTION__, counter->name, counter->id, cycles, counter->overhead);
 
 	// Invoke callbacks
 	while(hook) {

--- a/simavr/sim/sim_cycle_counters.c
+++ b/simavr/sim/sim_cycle_counters.c
@@ -168,7 +168,7 @@ _avr_cycle_counter_stop(
 
 	cycles = avr->cycle - counter->start - counter->overhead;
 
-	AVR_LOG(avr, LOG_TRACE, LOG_PREFIX "%s: counter '%s' measured %" PRI_avr_cycle_count " cycle(s)\n", __FUNCTION__, counter->name, cycles);
+	AVR_LOG(avr, LOG_TRACE, LOG_PREFIX "%s: counter '%s' measured %" PRI_avr_cycle_count " cycle(s) (overhead %" PRI_avr_cycle_count " cycle(s))\n", __FUNCTION__, counter->name, cycles, counter->overhead);
 
 	// Invoke callbacks
 	while(hook) {

--- a/simavr/sim/sim_cycle_counters.h
+++ b/simavr/sim/sim_cycle_counters.h
@@ -1,0 +1,125 @@
+/*
+	sim_cycle_counters.h
+
+	Copyright 2014 Florian Albrechtskirchinger <falbrechtskirchinger@gmail.com>
+
+	This file is part of simavr.
+
+	simavr is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	simavr is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with simavr.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Cycle counters allow measuring the execution time of code blocks.
+ * This is particularly convenient when used with MCU section macros.
+ * The counters attempt to account for overhead incurred by the instructions
+ * used to communicate with simavr. This even works when nesting counters.
+ * The method employed is quite limited though and not accurate in all cases.
+ *
+ * Another shortcoming of the current implementation is that any time spent
+ * servicing IRQs is included in the measurement.
+ */
+
+#pragma once
+
+#include "sim_avr_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define MAX_CYCLE_COUNTERS	32
+
+typedef struct avr_cycle_counter_t {
+	struct avr_cycle_counter_t * prev;
+	char name[32];
+	avr_cycle_count_t start;
+	avr_cycle_count_t overhead;
+	uint8_t registered:1;
+} avr_cycle_counter_t;
+
+typedef void (*avr_cycle_counter_notify_t)(
+	struct avr_t * avr,
+	avr_cycle_counter_t * counter,
+	avr_cycle_count_t cycles,
+	void * param);
+
+typedef struct avr_cycle_counter_pool_t {
+	avr_cycle_counter_t counters[MAX_CYCLE_COUNTERS];
+	avr_cycle_counter_t * counter_tail;		// Tail pointer to the list of active counters
+	struct avr_cycle_counter_hook_t * hook;
+} avr_cycle_counter_pool_t;
+
+/*
+ * Define a new cycle counter.
+ * 'id' is used as numerical handle to subsequently refer to the counter.
+ * 'name' can optionally be used to associate a human-readable identifier with
+ * the counter.
+ */
+void
+avr_cycle_counter_register(
+		struct avr_t * avr,
+		uint8_t id,
+		const char * name);
+
+void
+avr_cycle_counter_unregister(
+		struct avr_t * avr,
+		uint8_t id);
+
+void
+avr_cycle_counter_start(
+		struct avr_t * avr,
+		uint8_t id);
+
+void
+avr_cycle_counter_stop(
+		struct avr_t * avr);
+
+/*
+ * Register a callback to be invoked when the counter is stopped
+ * and a measurement has been obtained.
+ */
+void
+avr_cycle_counter_register_notify(
+		struct avr_t * avr,
+		avr_cycle_counter_notify_t notify,
+		void * param);
+
+void
+avr_cycle_counter_unregister_notify(
+		struct avr_t * avr,
+		avr_cycle_counter_notify_t notify,
+		void * param);
+
+// Private functions
+
+void
+avr_cycle_counter_init(
+		struct avr_t * avr);
+
+// Called from the respective builtin commands
+void
+avr_cycle_counter_start_with_overhead(
+		struct avr_t * avr,
+		uint8_t id,
+		avr_cycle_count_t overhead);
+
+void
+avr_cycle_counter_stop_with_overhead(
+		struct avr_t * avr,
+		avr_cycle_count_t overhead);
+
+#ifdef __cplusplus
+};
+#endif

--- a/simavr/sim/sim_cycle_counters.h
+++ b/simavr/sim/sim_cycle_counters.h
@@ -45,6 +45,7 @@ typedef struct avr_cycle_counter_t {
 	char name[32];
 	avr_cycle_count_t start;
 	avr_cycle_count_t overhead;
+	uint8_t id;
 	uint8_t registered:1;
 } avr_cycle_counter_t;
 

--- a/simavr/sim/sim_elf.h
+++ b/simavr/sim/sim_elf.h
@@ -22,6 +22,7 @@
 #ifndef __SIM_ELF_H__
 #define __SIM_ELF_H__
 
+#include "sim_cycle_counters.h"
 #include "avr/avr_mcu_section.h"
 
 #ifdef __cplusplus
@@ -53,6 +54,12 @@ typedef struct elf_firmware_t {
 		uint16_t addr;
 		char	name[64];
 	} trace[32];
+
+	int		cycle_counters_count;
+	struct {
+		uint8_t	id;
+		char	name[32];
+	} cycle_counters[MAX_CYCLE_COUNTERS];
 
 	struct {
 		char port;

--- a/tests/atmega88_cycle_counters.c
+++ b/tests/atmega88_cycle_counters.c
@@ -1,0 +1,70 @@
+#include <avr/io.h>
+#include <avr/sleep.h>
+
+#include "avr_mcu_section.h"
+
+enum {
+	OUTER_CYCLE_COUNTER,
+	INNER_CYCLE_COUNTER,
+};
+
+AVR_MCU(F_CPU, "atmega88");
+AVR_MCU_SIMAVR_COMMAND(&GPIOR0);
+
+const struct avr_mmcu_cycle_counter_t _cycle_counters[] _MMCU_ = {
+	{ AVR_MCU_CYCLE_COUNTER(OUTER_CYCLE_COUNTER, "Outer") },
+	{ AVR_MCU_CYCLE_COUNTER(INNER_CYCLE_COUNTER, "Inner") },
+};
+
+int main(void) {
+	asm volatile(
+		// PORTB output
+		"ldi	r16, 0xff\n\t"
+		"out	%[_DDRB], r16\n\t"
+
+		// Load commands & IDs into registers
+		"ldi	r16, %[_SIMAVR_CMD_START_CYCLE_COUNTER]\n\t"
+		"ldi	r17, %[_OUTER_CYCLE_COUNTER]\n\t"
+		"ldi	r18, %[_INNER_CYCLE_COUNTER]\n\t"
+		"ldi	r19, %[_SIMAVR_CMD_STOP_CYCLE_COUNTER]\n\t"
+
+		// Start outer cycle counter
+		"out	%[_GPIOR0], r16\n\t"
+		"out	%[_GPIOR0], r17\n\t"
+
+		// Setup loop counter for 10 iterations
+		// (1 cycle)
+		"ldi	r20, 10\n\t"
+
+		// Start inner cycle counter
+	"0: "	"out	%[_GPIOR0], r16\n\t"
+		"out	%[_GPIOR0], r18\n\t"
+
+		// Toggle PORTB
+		// (3 cycles per iteration)
+		"in	r21, %[_PORTB]\n\t"
+		"com	r21\n\t"
+		"out	%[_PORTB], r21\n\t"
+
+		// Stop inner cycle counter
+		"out	%[_GPIOR0], r19\n\t"
+
+		// Decrement loop counter and branch
+		// (9x 3 cycles, 1x 2 cycles)
+		"subi	r20, 1\n\t"
+		"brne	0b\n\t"
+
+		// Stop outer cycle counter
+		"out	%[_GPIOR0], r19\n\t"
+		:
+		: [_DDRB] "I" (_SFR_IO_ADDR(DDRB)),
+		  [_PORTB] "I" (_SFR_IO_ADDR(PORTB)),
+		  [_GPIOR0] "I" (_SFR_IO_ADDR(GPIOR0)),
+		  [_SIMAVR_CMD_START_CYCLE_COUNTER] "M" (SIMAVR_CMD_START_CYCLE_COUNTER),
+		  [_SIMAVR_CMD_STOP_CYCLE_COUNTER] "M" (SIMAVR_CMD_STOP_CYCLE_COUNTER),
+		  [_OUTER_CYCLE_COUNTER] "M" (OUTER_CYCLE_COUNTER),
+		  [_INNER_CYCLE_COUNTER] "M" (INNER_CYCLE_COUNTER)
+		: "r16", "r17", "r18", "r19", "r20", "r21");
+
+	sleep_cpu();
+}

--- a/tests/test_atmega88_cycle_counters.c
+++ b/tests/test_atmega88_cycle_counters.c
@@ -2,6 +2,11 @@
 #include <string.h>
 #include "tests.h"
 
+enum {
+	OUTER_CYCLE_COUNTER,
+	INNER_CYCLE_COUNTER,
+};
+
 static int success = 1;
 
 static void
@@ -11,10 +16,10 @@ notify(
 		avr_cycle_count_t cycles,
 		void * param)
 {
-	if(strcmp(counter->name, "Outer") == 0 && cycles != 60 && counter->overhead != 31)
+	if(counter->id == OUTER_CYCLE_COUNTER && cycles != 60 && counter->overhead != 31)
 		success = 0;
 
-	if(strcmp(counter->name, "Inner") == 0 && cycles != 3 && counter->overhead != 1)
+	if(counter->id == INNER_CYCLE_COUNTER && cycles != 3 && counter->overhead != 1)
 		success = 0;
 }
 

--- a/tests/test_atmega88_cycle_counters.c
+++ b/tests/test_atmega88_cycle_counters.c
@@ -1,0 +1,35 @@
+#include <stdlib.h>
+#include <string.h>
+#include "tests.h"
+
+static int success = 1;
+
+static void
+notify(
+		avr_t * avr,
+		avr_cycle_counter_t * counter,
+		avr_cycle_count_t cycles,
+		void * param)
+{
+	if(strcmp(counter->name, "Outer") == 0 && cycles != 60 && counter->overhead != 31)
+		success = 0;
+
+	if(strcmp(counter->name, "Inner") == 0 && cycles != 3 && counter->overhead != 1)
+		success = 0;
+}
+
+int main(int argc, char **argv)
+{
+	avr_t * avr;
+
+	tests_init(argc, argv);
+
+	avr = tests_init_avr("atmega88_cycle_counters.axf");
+	avr_cycle_counter_register_notify(avr, &notify, NULL);
+	tests_run_test(avr, 1000);
+
+	if(success)
+		tests_success();
+
+	return 0;
+}

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -79,7 +79,7 @@ static int my_avr_run(avr_t * avr)
 	// until the next timer is due
 	avr_cycle_count_t sleep = avr_cycle_timer_process(avr);
 
-	avr->pc = new_pc;
+	avr_set_pc(avr, new_pc);
 
 	if (avr->state == cpu_Sleeping) {
 		if (!avr->sreg[S_I]) {


### PR DESCRIPTION
These commits add a facility for measuring the execution time of code blocks and macros to do so conveniently from firmware code.
When nesting these counters, the overhead incurred by starting and stopping counters (i.e. the associated 'ldi'/'eor', 'out' instructions) is accounted for, although the method used is limited and if the instructions aren't grouped together, they will be ignored.
IRQs interrupting the instrumented code, do not pause the counters, an issue I wish to address soon-ish.

Starting a counter from firmware code requires sending a two-byte command, therefore command handling was rewritten and put in a separate file. It now supports multi-byte commands and permits users to register additional command handlers.

The avr_set_pc() helper takes care of preserving the previous PC, when setting a new one, required for overhead accounting.

A test case was added to verify cycle counter accuracy.
