### PR TITLE
parts: Bug fix for i2c_eeprom part

### DIFF
--- a/examples/board_i2ctest/i2ctest.c
+++ b/examples/board_i2ctest/i2ctest.c
@@ -54,8 +54,8 @@ int main(int argc, char *argv[])
 	avr_init(avr);
 	avr_load_firmware(avr, &f);
 
-	// initialize our 'peripheral'
-	i2c_eeprom_init(avr, &ee, 0xa0, 0xfe, NULL, 1024);
+	// initialize our 'peripheral', setting the mask to allow read and write
+	i2c_eeprom_init(avr, &ee, 0xa0, 0x01, NULL, 1024);
 
 	i2c_eeprom_attach(avr, &ee, AVR_IOCTL_TWI_GETIRQ(0));
 	ee.verbose = 1;

--- a/examples/parts/i2c_eeprom.c
+++ b/examples/parts/i2c_eeprom.c
@@ -60,8 +60,10 @@ i2c_eeprom_in_hook(
 	if (v.u.twi.msg & TWI_COND_START) {
 		p->selected = 0;
 		p->index = 0;
-		if ((p->addr_base & p->addr_mask) == (v.u.twi.addr & p->addr_mask)) {
+		if ((p->addr_base & ~p->addr_mask) == (v.u.twi.addr & ~p->addr_mask)) {
 			// it's us !
+			if (p->verbose)
+				printf("eeprom received start\n");
 			p->selected = v.u.twi.addr;
 			avr_raise_irq(p->irq + TWI_IRQ_INPUT,
 					avr_twi_irq_msg(TWI_COND_ACK, p->selected, 1));
@@ -129,6 +131,10 @@ i2c_eeprom_init(
 {
 	memset(p, 0, sizeof(*p));
 	memset(p->ee, 0xff, sizeof(p->ee));
+
+	p->addr_base = addr;
+	p->addr_mask = mask;
+
 	p->irq = avr_alloc_irq(&avr->irq_pool, 0, 2, _ee_irq_names);
 	avr_irq_register_notify(p->irq + TWI_IRQ_OUTPUT, i2c_eeprom_in_hook, p);
 


### PR DESCRIPTION
```
Fixes:

> Part address and mask weren't set in i2c_eeprom_init. The
  virtual part responded to all addresses.
> Mask required inverting to function as per the description in
  i2c_eeprom.h
```
