### PR TITLE
twi: Clear TWSTO bit after STOP condition transmitted

### DIFF
--- a/simavr/sim/avr_twi.c
+++ b/simavr/sim/avr_twi.c
@@ -182,6 +182,7 @@ avr_twi_write(
 			if (p->state & TWI_COND_START) {
 				avr_raise_irq(p->io.irq + TWI_IRQ_OUTPUT,
 						avr_twi_irq_msg(TWI_COND_STOP, p->peer_addr, 1));
+				avr_regbit_clear(avr, p->twsto);
 			}
 		}
 		p->state = 0;


### PR DESCRIPTION
> This change fixes a problem where a TWI driver polling the
>   TWSTO bit would run on the real device but not simavr.
> 
> More detail in for example p188 of the ATMega32A datasheet
>   (rev 815D-AVR-10/2013).
