### PR TITLE
Changes to allow for free run in core between cycle timers

### DIFF
--- a/simavr/sim/sim_avr.h
+++ b/simavr/sim/sim_avr.h
@@ -162,6 +162,11 @@ typedef struct avr_t {
 	// like, sleeping.
 	avr_cycle_count_t	cycle;		// current cycle
 
+	// these next two allow the core to freely run between cycle timers and also allows
+	// for a maximum run cycle limit... run_cycle_count is set during cycle timer processing.
+	avr_cycle_count_t	run_cycle_count;	// cycles to run before next timer
+	avr_cycle_count_t	run_cycle_limit;	// maximum run cycle interval limit
+
 	/**
 	 * Sleep requests are accumulated in sleep_usec until the minimum sleep value
 	 * is reached, at which point sleep_usec is cleared and the sleep request

--- a/simavr/sim/sim_core.c
+++ b/simavr/sim/sim_core.c
@@ -581,6 +581,7 @@ static inline int _avr_is_instruction_32_bits(avr_t * avr, avr_flashaddr_t pc)
  */
 avr_flashaddr_t avr_run_one(avr_t * avr)
 {
+run_one_again:
 #if CONFIG_SIMAVR_TRACE
 	/*
 	 * this traces spurious reset or bad jumps
@@ -1402,6 +1403,16 @@ avr_flashaddr_t avr_run_one(avr_t * avr)
 
 	}
 	avr->cycle += cycle;
+	
+	if( (avr->state == cpu_Running) && 
+		(avr->run_cycle_count > cycle) && 
+		!(avr->sreg[S_I] && avr_has_pending_interrupts(avr)) )
+	{
+		avr->run_cycle_count -= cycle;
+		avr->pc = new_pc;
+		goto run_one_again;
+	}
+	
 	return new_pc;
 }
 


### PR DESCRIPTION
Changes to allow for free run in core between cycle timers with per interval limiting.

Average cycle times drop by about upwards of 50-60+ cycles per emulated cycle,
    dependant on usage.

sim_avr.h: struct avr_t changed.
    added members run_cycle_count and run_cycle_limit.
    run_cycle_count is number of cycles till next cycle timer.
    run_cycle_limit is maximum number of cycles to run per interval.

sim_core.c: avr_run_one
    \* run_one_again label added at top.
    \* clause added at end which loops to run_one_again given that the core
        is still in a cpu_Running state, run_cycle_count is greater than
        cycles, and no interrups are pending.

sim_cycle_timers.c:
    \* static avr_cycle_timer_return_sleep_run_cycles_limited() added.
        run_cycle_count is bounded to run_cycle_limit.
        returns sleep count unbounded, preserving original behavior.

```
* static avr_cycle_timer_reset_sleep_run_cycles_limited() added.
    sets new run_cycle_count based on present list of cycle timers.

* avr_cycle_timer_reset() changed.
    run_cycle_count and run_cycle_limit is set to default values.

* avr_cycle_timer_register() changed.
* avr_cycle_timer_cancel() changed.
* avr_cycle_timer_process() changed.
    call the relevant function to set/maintain run_cycle_count.

modified:   simavr/sim/sim_avr.c
modified:   simavr/sim/sim_avr.h
modified:   simavr/sim/sim_cycle_timers.c
```
