### PR TITLE
cores: Adds missing peripherals to m16/m32

### DIFF
--- a/simavr/cores/sim_mega8.c
+++ b/simavr/cores/sim_mega8.c
@@ -1,5 +1,5 @@
 /*
-	sim_mega88.c
+	sim_mega8.c
 
 	Copyright 2008, 2009 Michel Pollet <buserror@gmail.com>
 
@@ -20,10 +20,19 @@
  */
 
 #include "sim_avr.h"
+#include "sim_core_declare.h"
+#include "avr_eeprom.h"
+#include "avr_flash.h"
+#include "avr_watchdog.h"
+#include "avr_extint.h"
+#include "avr_ioport.h"
+#include "avr_uart.h"
+#include "avr_adc.h"
+#include "avr_timer.h"
+#include "avr_spi.h"
+#include "avr_twi.h"
 
 #define SIM_VECTOR_SIZE	2
-#define SIM_MMCU		"atmega8"
-#define SIM_CORENAME	mcu_mega8
 
 #define ICP_PORT	PORTB
 #define ICP_PIN		0
@@ -31,12 +40,286 @@
 #define _AVR_IO_H_
 #define __ASSEMBLER__
 #include "avr/iom8.h"
-// instantiate the new core
-#include "sim_megax.h"
+
+#ifndef EFUSE_DEFAULT
+#define EFUSE_DEFAULT 0xff
+#endif
+#define EICRA MCUCR
+#define EIMSK GICR
+#define EIFR GIFR
+
+static void m8_init(struct avr_t * avr);
+static void m8_reset(struct avr_t * avr);
+
+const struct mcu_t {
+	avr_t          core;
+	avr_eeprom_t 	eeprom;
+	avr_flash_t 	selfprog;
+	avr_watchdog_t	watchdog;
+	avr_extint_t	extint;
+	avr_ioport_t	portb, portc, portd;
+	avr_uart_t		uart;
+	avr_adc_t		adc;
+	avr_timer_t		timer0,timer1,timer2;
+	avr_spi_t		spi;
+	avr_twi_t		twi;
+} mcu_mega8 = {
+	.core = {
+		.mmcu = "atmega8",
+		DEFAULT_CORE(SIM_VECTOR_SIZE),
+
+		.init = m8_init,
+		.reset = m8_reset,
+	},
+	AVR_EEPROM_DECLARE_NOEEPM(EE_RDY_vect),
+	AVR_SELFPROG_DECLARE(SPMCR, SPMEN, SPM_RDY_vect),
+	AVR_WATCHDOG_DECLARE_128(WDTCR, _VECTOR(0)),
+	.extint = {
+		AVR_EXTINT_DECLARE(0, 'D', PD2),
+		AVR_EXTINT_DECLARE(1, 'D', PD3),
+	},
+	.portb = {
+		.name = 'B', .r_port = PORTB, .r_ddr = DDRB, .r_pin = PINB,
+	},
+	.portc = {
+		.name = 'C', .r_port = PORTC, .r_ddr = DDRC, .r_pin = PINC,
+	},
+	.portd = {
+		.name = 'D', .r_port = PORTD, .r_ddr = DDRD, .r_pin = PIND,
+	},
+	.uart = {
+	   // no PRUSART .disabled = AVR_IO_REGBIT(PRR,PRUSART0),
+		.name = '0',
+		.r_udr = UDR,
+
+		.txen = AVR_IO_REGBIT(UCSRB, TXEN),
+		.rxen = AVR_IO_REGBIT(UCSRB, RXEN),
+		.ucsz = AVR_IO_REGBITS(UCSRC, UCSZ0, 0x3), // 2 bits
+		.ucsz2 = AVR_IO_REGBIT(UCSRB, UCSZ2), 	// 1 bits
+
+		.r_ucsra = UCSRA,
+		.r_ucsrb = UCSRB,
+		.r_ucsrc = UCSRC,
+		.r_ubrrl = UBRRL,
+		.r_ubrrh = UBRRH,
+		.rxc = {
+			.enable = AVR_IO_REGBIT(UCSRB, RXCIE),
+			.raised = AVR_IO_REGBIT(UCSRA, RXC),
+			.vector = USART_RXC_vect,
+		},
+		.txc = {
+			.enable = AVR_IO_REGBIT(UCSRB, TXCIE),
+			.raised = AVR_IO_REGBIT(UCSRA, TXC),
+			.vector = USART_TXC_vect,
+		},
+		.udrc = {
+			.enable = AVR_IO_REGBIT(UCSRB, UDRIE),
+			.raised = AVR_IO_REGBIT(UCSRA, UDRE),
+			.vector = USART_UDRE_vect,
+		},
+	},
+	.adc = {
+		.r_admux = ADMUX,
+		.mux = { AVR_IO_REGBIT(ADMUX, MUX0), AVR_IO_REGBIT(ADMUX, MUX1),
+					AVR_IO_REGBIT(ADMUX, MUX2), AVR_IO_REGBIT(ADMUX, MUX3),},
+		.ref = { AVR_IO_REGBIT(ADMUX, REFS0), AVR_IO_REGBIT(ADMUX, REFS1)},
+		.ref_values = { [1] = ADC_VREF_AVCC, [3] = ADC_VREF_V256 },
+
+		.adlar = AVR_IO_REGBIT(ADMUX, ADLAR),
+		.r_adcsra = ADCSRA,
+		.aden = AVR_IO_REGBIT(ADCSRA, ADEN),
+		.adsc = AVR_IO_REGBIT(ADCSRA, ADSC),
+		// no ADATE .adate = AVR_IO_REGBIT(ADCSRA, ADATE),
+		.adps = { AVR_IO_REGBIT(ADCSRA, ADPS0), AVR_IO_REGBIT(ADCSRA, ADPS1), AVR_IO_REGBIT(ADCSRA, ADPS2),},
+
+		.r_adch = ADCH,
+		.r_adcl = ADCL,
+
+		//.r_adcsrb = ADCSRB,
+		// .adts = { AVR_IO_REGBIT(ADCSRB, ADTS0), AVR_IO_REGBIT(ADCSRB, ADTS1), AVR_IO_REGBIT(ADCSRB, ADTS2),},
+
+		.muxmode = {
+			[0] = AVR_ADC_SINGLE(0), [1] = AVR_ADC_SINGLE(1),
+			[2] = AVR_ADC_SINGLE(2), [3] = AVR_ADC_SINGLE(3),
+			[4] = AVR_ADC_SINGLE(4), [5] = AVR_ADC_SINGLE(5),
+			[6] = AVR_ADC_SINGLE(6), [7] = AVR_ADC_SINGLE(7),
+
+			[14] = AVR_ADC_REF(1300),	// 1.30V
+			[15] = AVR_ADC_REF(0),		// GND
+		},
+
+		.adc = {
+			.enable = AVR_IO_REGBIT(ADCSRA, ADIE),
+			.raised = AVR_IO_REGBIT(ADCSRA, ADIF),
+			.vector = ADC_vect,
+		},
+	},
+	.timer0 = {
+		.name = '0',
+		.wgm_op = {
+			[0] = AVR_TIMER_WGM_NORMAL8(),
+			// CTC etc. are missing because atmega8 does not support them on timer0
+		},
+		.cs = { AVR_IO_REGBIT(TCCR0, CS00), AVR_IO_REGBIT(TCCR0, CS01), AVR_IO_REGBIT(TCCR0, CS02) },
+		.cs_div = { 0, 0, 3 /* 8 */, 6 /* 64 */, 8 /* 256 */, 10 /* 1024 */},
+
+		.r_tcnt = TCNT0,
+
+		.overflow = {
+			.enable = AVR_IO_REGBIT(TIMSK, TOIE0),
+			.raised = AVR_IO_REGBIT(TIFR, TOV0),
+			.vector = TIMER0_OVF_vect,
+		},
+		// Compare Output Mode is missing for timer0 as atmega8 does not support it
+	},
+	.timer1 = {
+		.name = '1',
+		.wgm = { AVR_IO_REGBIT(TCCR1A, WGM10), AVR_IO_REGBIT(TCCR1A, WGM11),
+					AVR_IO_REGBIT(TCCR1B, WGM12), AVR_IO_REGBIT(TCCR1B, WGM13) },
+		.wgm_op = {
+			[0] = AVR_TIMER_WGM_NORMAL16(),
+			// TODO: 1 PWM phase correct 8bit
+			// 		 2 PWM phase correct 9bit
+			//       3 PWM phase correct 10bit
+			[4] = AVR_TIMER_WGM_CTC(),
+			[5] = AVR_TIMER_WGM_FASTPWM8(),
+			[6] = AVR_TIMER_WGM_FASTPWM9(),
+			[7] = AVR_TIMER_WGM_FASTPWM10(),
+			// TODO: 8, 9 PWM phase and freq correct ICR & 10, 11
+			[12] = AVR_TIMER_WGM_ICCTC(),
+			[14] = AVR_TIMER_WGM_ICPWM(),
+			[15] = AVR_TIMER_WGM_OCPWM(),
+		},
+		.cs = { AVR_IO_REGBIT(TCCR1B, CS10), AVR_IO_REGBIT(TCCR1B, CS11), AVR_IO_REGBIT(TCCR1B, CS12) },
+		.cs_div = { 0, 0, 3 /* 8 */, 6 /* 64 */, 8 /* 256 */, 10 /* 1024 */  /* TODO: 2 External clocks */},
+
+		.r_tcnt = TCNT1L,
+		.r_icr = ICR1L,
+		.r_icrh = ICR1H,
+		.r_tcnth = TCNT1H,
+
+		.ices = AVR_IO_REGBIT(TCCR1B, ICES1),
+		.icp = AVR_IO_REGBIT(ICP_PORT, ICP_PIN),
+
+		.overflow = {
+			.enable = AVR_IO_REGBIT(TIMSK, TOIE1),
+			.raised = AVR_IO_REGBIT(TIFR, TOV1),
+			.vector = TIMER1_OVF_vect,
+		},
+		.icr = {
+			.enable = AVR_IO_REGBIT(TIMSK, TICIE1),
+			.raised = AVR_IO_REGBIT(TIFR, ICF1),
+			.vector = TIMER1_CAPT_vect,
+		},
+		.comp = {
+			[AVR_TIMER_COMPA] = {
+				.r_ocr = OCR1AL,
+				.r_ocrh = OCR1AH,	// 16 bits timers have two bytes of it
+				.com = AVR_IO_REGBITS(TCCR1A, COM1A0, 0x3),
+				.com_pin = AVR_IO_REGBIT(PORTB, PB5),
+				.interrupt = {
+					.enable = AVR_IO_REGBIT(TIMSK, OCIE1A),
+					.raised = AVR_IO_REGBIT(TIFR, OCF1A),
+					.vector = TIMER1_COMPA_vect,
+				},
+			},
+			[AVR_TIMER_COMPB] = {
+				.r_ocr = OCR1BL,
+				.r_ocrh = OCR1BH,
+				.com = AVR_IO_REGBITS(TCCR1A, COM1B0, 0x3),
+				.com_pin = AVR_IO_REGBIT(PORTB, PB6),
+				.interrupt = {
+					.enable = AVR_IO_REGBIT(TIMSK, OCIE1B),
+					.raised = AVR_IO_REGBIT(TIFR, OCF1B),
+					.vector = TIMER1_COMPB_vect,
+				},
+			},
+		},
+
+	},
+	.timer2 = {
+		.name = '2',
+		.wgm = { AVR_IO_REGBIT(TCCR2, WGM20), AVR_IO_REGBIT(TCCR2, WGM21) },
+		.wgm_op = {
+			[0] = AVR_TIMER_WGM_NORMAL8(),
+			// TODO 1 pwm phase correct
+			[2] = AVR_TIMER_WGM_CTC(),
+			[3] = AVR_TIMER_WGM_FASTPWM8(),
+		},
+		.cs = { AVR_IO_REGBIT(TCCR2, CS20), AVR_IO_REGBIT(TCCR2, CS21), AVR_IO_REGBIT(TCCR2, CS22) },
+		.cs_div = { 0, 0, 3 /* 8 */, 4 /* 32 */, 6 /* 64 */, 7 /* 128 */, 8 /* 256 */, 10 /* 1024 */ /* TODO external clock */ },
+
+		.r_tcnt = TCNT2,
+
+		// asynchronous timer source bit.. if set, use 32khz frequency
+		.as2 = AVR_IO_REGBIT(ASSR, AS2),
+
+		.overflow = {
+			.enable = AVR_IO_REGBIT(TIMSK, TOIE2),
+			.raised = AVR_IO_REGBIT(TIFR, TOV2),
+			.vector = TIMER2_OVF_vect,
+		},
+		.comp = {
+			[AVR_TIMER_COMPA] = {
+				.r_ocr = OCR2,
+				.com = AVR_IO_REGBITS(TCCR2, COM20, 0x3),
+				.com_pin = AVR_IO_REGBIT(PORTB, PB7), // same as timer1C
+				.interrupt = {
+					.enable = AVR_IO_REGBIT(TIMSK, OCIE2),
+					.raised = AVR_IO_REGBIT(TIFR, OCF2),
+					.vector = TIMER2_COMP_vect,
+				},
+			},
+		},
+	},
+	.spi = {
+
+		.r_spdr = SPDR,
+		.r_spcr = SPCR,
+		.r_spsr = SPSR,
+
+		.spe = AVR_IO_REGBIT(SPCR, SPE),
+		.mstr = AVR_IO_REGBIT(SPCR, MSTR),
+
+		.spr = { AVR_IO_REGBIT(SPCR, SPR0), AVR_IO_REGBIT(SPCR, SPR1), AVR_IO_REGBIT(SPSR, SPI2X) },
+		.spi = {
+			.enable = AVR_IO_REGBIT(SPCR, SPIE),
+			.raised = AVR_IO_REGBIT(SPSR, SPIF),
+			.vector = SPI_STC_vect,
+		},
+	},
+
+	.twi = {
+
+		.r_twcr = TWCR,
+		.r_twsr = TWSR,
+		.r_twbr = TWBR,
+		.r_twdr = TWDR,
+		.r_twar = TWAR,
+		// no .r_twamr = TWAMR,
+
+		.twen = AVR_IO_REGBIT(TWCR, TWEN),
+		.twea = AVR_IO_REGBIT(TWCR, TWEA),
+		.twsta = AVR_IO_REGBIT(TWCR, TWSTA),
+		.twsto = AVR_IO_REGBIT(TWCR, TWSTO),
+		.twwc = AVR_IO_REGBIT(TWCR, TWWC),
+
+		.twsr = AVR_IO_REGBITS(TWSR, TWS3, 0x1f),	// 5 bits
+		.twps = AVR_IO_REGBITS(TWSR, TWPS0, 0x3),	// 2 bits
+
+		.twi = {
+			.enable = AVR_IO_REGBIT(TWCR, TWIE),
+			.raised = AVR_IO_REGBIT(TWCR, TWINT),
+			.raise_sticky = 1,
+			.vector = TWI_vect,
+		},
+	},
+
+};
 
 static avr_t * make()
 {
-	return avr_core_allocate(&SIM_CORENAME.core, sizeof(struct mcu_t));
+	return avr_core_allocate(&mcu_mega8.core, sizeof(struct mcu_t));
 }
 
 avr_kind_t mega8 = {
@@ -44,3 +327,27 @@ avr_kind_t mega8 = {
 	.make = make
 };
 
+static void m8_init(struct avr_t * avr)
+{
+	struct mcu_t * mcu = (struct mcu_t*)avr;
+
+	avr_eeprom_init(avr, &mcu->eeprom);
+	avr_flash_init(avr, &mcu->selfprog);
+	avr_watchdog_init(avr, &mcu->watchdog);
+	avr_extint_init(avr, &mcu->extint);
+	avr_ioport_init(avr, &mcu->portb);
+	avr_ioport_init(avr, &mcu->portc);
+	avr_ioport_init(avr, &mcu->portd);
+	avr_uart_init(avr, &mcu->uart);
+	avr_adc_init(avr, &mcu->adc);
+	avr_timer_init(avr, &mcu->timer0);
+	avr_timer_init(avr, &mcu->timer1);
+	avr_timer_init(avr, &mcu->timer2);
+	avr_spi_init(avr, &mcu->spi);
+	avr_twi_init(avr, &mcu->twi);
+}
+
+static void m8_reset(struct avr_t * avr)
+{
+//	struct mcu_t * mcu = (struct mcu_t*)avr;
+}

--- a/simavr/cores/sim_megax.c
+++ b/simavr/cores/sim_megax.c
@@ -20,8 +20,6 @@
  */
 
 #include "sim_avr.h"
-
-
 #include "sim_megax.h"
 
 void mx_init(struct avr_t * avr)
@@ -32,9 +30,7 @@ void mx_init(struct avr_t * avr)
 	avr_flash_init(avr, &mcu->selfprog);
 	avr_watchdog_init(avr, &mcu->watchdog);
 	avr_extint_init(avr, &mcu->extint);
-#ifdef PORTA
 	avr_ioport_init(avr, &mcu->porta);
-#endif
 	avr_ioport_init(avr, &mcu->portb);
 	avr_ioport_init(avr, &mcu->portc);
 	avr_ioport_init(avr, &mcu->portd);

--- a/simavr/cores/sim_megax.h
+++ b/simavr/cores/sim_megax.h
@@ -1,7 +1,8 @@
 /*
-	sim_mega128.c
+	sim_megax.h
 
 	Copyright 2008, 2009 Michel Pollet <buserror@gmail.com>
+	Copyright 2014 Doug Szumski  <d.s.szumski@gmail.com>
 
  	This file is part of simavr.
 
@@ -38,7 +39,7 @@ void mx_init(struct avr_t * avr);
 void mx_reset(struct avr_t * avr);
 
 /*
- * This is a template for all of the 8/32/64 devices, hopefully
+ * This is a template for all of the 16/32 devices, hopefully
  */
 struct mcu_t {
 	avr_t          core;
@@ -46,16 +47,12 @@ struct mcu_t {
 	avr_flash_t 	selfprog;
 	avr_watchdog_t	watchdog;
 	avr_extint_t	extint;
-	avr_ioport_t	portb, portc, portd;
+	avr_ioport_t	porta, portb, portc, portd;
 	avr_uart_t		uart;
 	avr_adc_t		adc;
 	avr_timer_t		timer0,timer1,timer2;
 	avr_spi_t		spi;
 	avr_twi_t		twi;
-	// PORTA exists on m16 and 32, but not on 8. 
-	// It is still necessary to declare this as otherwise
-	// the core_megax shared constructor will be confused
-	avr_ioport_t	porta;
 };
 
 #ifdef SIM_CORENAME
@@ -88,12 +85,11 @@ const struct mcu_t SIM_CORENAME = {
 	.extint = {
 		AVR_EXTINT_DECLARE(0, 'D', PD2),
 		AVR_EXTINT_DECLARE(1, 'D', PD3),
+		AVR_ASYNC_EXTINT_DECLARE(2, 'B', PB2),
 	},
-#ifdef PORTA
 	.porta = {
 		.name = 'A', .r_port = PORTA, .r_ddr = DDRA, .r_pin = PINA,
 	},
-#endif
 	.portb = {
 		.name = 'B', .r_port = PORTB, .r_ddr = DDRB, .r_pin = PINB,
 	},

--- a/simavr/sim/avr_extint.h
+++ b/simavr/sim/avr_extint.h
@@ -4,6 +4,7 @@
 	External Interrupt Handling (for INT0-3)
 
 	Copyright 2008, 2009 Michel Pollet <buserror@gmail.com>
+	Copyright 2014 Doug Szumski <d.s.szumski@gmail.com>
 
  	This file is part of simavr.
 
@@ -75,6 +76,20 @@ void avr_extint_init(avr_t * avr, avr_extint_t * p);
 			.vector = { \
 				.enable = AVR_IO_REGBIT(EIMSK, INT##_index), \
 				.raised = AVR_IO_REGBIT(EIFR, INTF##_index), \
+				.vector = INT##_index##_vect, \
+			},\
+		}
+
+// Asynchronous External Interrupt, for example INT2 on the m16 and m32
+// Uses only 1 interrupt sense control bit
+#define AVR_ASYNC_EXTINT_DECLARE(_index, _portname, _portpin) \
+		.eint[_index] = { \
+			.port_ioctl = AVR_IOCTL_IOPORT_GETIRQ(_portname), \
+			.port_pin = _portpin, \
+			.isc = { AVR_IO_REGBIT(MCUCSR, ISC##_index) },\
+			.vector = { \
+				.enable = AVR_IO_REGBIT(GICR, INT##_index), \
+				.raised = AVR_IO_REGBIT(GIFR, INTF##_index), \
 				.vector = INT##_index##_vect, \
 			},\
 		}


### PR DESCRIPTION
> Port A not present on m16/m32 because PORTA was not defined in sim_megax.c for m16/32.
> Async external interrupt (INT2) missing on m16/32. Since unlike the others, this
>   interrupt uses only 1 bit for sense control avr_extint.\* were modified to support this
>   new mode.
> As a consequence of the above, the dependency of sim_mega8.c on sim_megax.c was removed
>   for simplicity.
