### PR TITLE
fifo: prevent potential misuse of _get_write_size()

### DIFF
--- a/simavr/sim/fifo_declare.h
+++ b/simavr/sim/fifo_declare.h
@@ -155,7 +155,7 @@ FIFO_DECL FIFO_INLINE FIFO_CURSOR_TYPE __name##_get_read_size(__name##_t *c)\
 }\
 FIFO_DECL FIFO_INLINE FIFO_CURSOR_TYPE __name##_get_write_size(__name##_t *c)\
 {\
-	return __name##_fifo_size - __name##_get_read_size(c);\
+	return (__name##_fifo_size-1) - __name##_get_read_size(c);\
 }\
 FIFO_DECL FIFO_INLINE void __name##_read_offset(__name##_t *c, FIFO_CURSOR_TYPE o)\
 {\


### PR DESCRIPTION
Using the number obtained from _get_write_size() and writing that many
items to the fifo yields to _isempty() becoming true and not to
_isfull() becoming true.

I got caught assuming the latter.

To avoid thinking about edge cases and prevent potential misuse of
_get_write_size(), I suggest that it returns one unit less, thus, a
number between 0 and (fifo_size-1).  E.g., if there is only one place
left in the fifo, i.e., _isfull() is true, it then returns 0, preventing
us to fill that place and get into a wrap overflow situation.

(Michel: Thanks for the great architecture you laid out and the great
code.)
