### PR TITLE
fix initialization of port_a on atmega16 devices.

### DIFF
--- a/simavr/cores/sim_megax.c
+++ b/simavr/cores/sim_megax.c
@@ -32,9 +32,8 @@ void mx_init(struct avr_t * avr)
 	avr_flash_init(avr, &mcu->selfprog);
 	avr_watchdog_init(avr, &mcu->watchdog);
 	avr_extint_init(avr, &mcu->extint);
-#ifdef PORTA
-	avr_ioport_init(avr, &mcu->porta);
-#endif
+	if((mcu->porta.name == 'A') && (mcu->porta.r_port != 0))
+		avr_ioport_init(avr, &mcu->porta);
 	avr_ioport_init(avr, &mcu->portb);
 	avr_ioport_init(avr, &mcu->portc);
 	avr_ioport_init(avr, &mcu->portd);


### PR DESCRIPTION
This should fix issue #89, Atmega16 core avr_io_getirq returns NULL for PORTA.

```
modified:   cores/sim_megax.c
    replace use of device specific macro with check
        for (in theory) ready to initialize port_a
        structure.
```
