### PR TITLE
Fix the issue where Intel HEX files with hex strings longer than 32 bytes would be truncated

### DIFF
--- a/simavr/sim/sim_hex.c
+++ b/simavr/sim/sim_hex.c
@@ -51,7 +51,7 @@ int read_hex_string(const char * src, uint8_t * buffer, int maxlen)
     uint8_t * dst = buffer;
     int ls = 0;
     uint8_t b = 0;
-    while (*src && maxlen--) {
+    while (*src && maxlen) {
         char c = *src++;
         switch (c) {
             case 'a' ... 'f':   b = (b << 4) | (c - 'a' + 0xa); break;
@@ -66,6 +66,7 @@ int read_hex_string(const char * src, uint8_t * buffer, int maxlen)
         }
         if (ls & 1) {
             *dst++ = b; b = 0;
+            maxlen--;
         }
         ls++;
     }


### PR DESCRIPTION
I discovered this error while attempting to use the ihex loader on a dumped AVR firmware file in Intel Hex format. Ideally, the code should decode the first byte of the string to determine the data length per the format's specification, but this will fix the problem just as easily and cover the majority of cases.
