### PR TITLE
cores: AVR_IOPORT_DECLARE

### DIFF
--- a/simavr/cores/sim_90usb162.c
+++ b/simavr/cores/sim_90usb162.c
@@ -89,9 +89,7 @@ const struct mcu_t {
 		},
 		.r_pcint = PCMSK1,
 	},
-	.portd = {
-		.name = 'D', .r_port = PORTD, .r_ddr = DDRD, .r_pin = PIND,
-	},
+	AVR_IOPORT_DECLARE(d, 'D', D),
 
 	.uart1 = {
 		.disabled = AVR_IO_REGBIT(PRR1,PRUSART1),

--- a/simavr/cores/sim_mega128.c
+++ b/simavr/cores/sim_mega128.c
@@ -77,27 +77,13 @@ const struct mcu_t {
 		AVR_EXTINT_MEGA_DECLARE(6, 'E', PE6, B),
 		AVR_EXTINT_MEGA_DECLARE(7, 'E', PE7, B),
 	},
-	.porta = {  // no PCINTs in atmega128
-		.name = 'A', .r_port = PORTA, .r_ddr = DDRA, .r_pin = PINA,
-	},
-	.portb = {
-		.name = 'B', .r_port = PORTB, .r_ddr = DDRB, .r_pin = PINB,
-	},
-	.portc = {
-		.name = 'C', .r_port = PORTC, .r_ddr = DDRC, .r_pin = PINC,
-	},
-	.portd = {
-		.name = 'D', .r_port = PORTD, .r_ddr = DDRD, .r_pin = PIND,
-	},
-	.porte = {
-		.name = 'E', .r_port = PORTE, .r_ddr = DDRE, .r_pin = PINE,
-	},
-	.portf = {
-		.name = 'F', .r_port = PORTF, .r_ddr = DDRF, .r_pin = PINF,
-	},
-	.portg = {
-		.name = 'G', .r_port = PORTG, .r_ddr = DDRG, .r_pin = PING,
-	},
+	AVR_IOPORT_DECLARE(a, 'A', A), // no PCINTs in atmega128
+	AVR_IOPORT_DECLARE(b, 'B', B),
+	AVR_IOPORT_DECLARE(c, 'C', C),
+	AVR_IOPORT_DECLARE(d, 'D', D),
+	AVR_IOPORT_DECLARE(e, 'E', E),
+	AVR_IOPORT_DECLARE(f, 'F', F),
+	AVR_IOPORT_DECLARE(g, 'G', G),
 
 	.uart0 = {
 	   // no PRUSART .disabled = AVR_IO_REGBIT(PRR,PRUSART0),

--- a/simavr/cores/sim_mega1280.c
+++ b/simavr/cores/sim_mega1280.c
@@ -81,9 +81,7 @@ const struct mcu_t {
 		AVR_EXTINT_MEGA_DECLARE(6, 'E', PE6, B),
 		AVR_EXTINT_MEGA_DECLARE(7, 'E', PE7, B),
 	},
-	.porta = {
-		.name = 'A', .r_port = PORTA, .r_ddr = DDRA, .r_pin = PINA,
-	},
+	AVR_IOPORT_DECLARE(a, 'A', A),
 	.portb = {
 		.name = 'B', .r_port = PORTB, .r_ddr = DDRB, .r_pin = PINB,
 		.pcint = {
@@ -93,35 +91,15 @@ const struct mcu_t {
 		},
 		.r_pcint = PCMSK0,
 	},
-	.portc = {
-		.name = 'C', .r_port = PORTC, .r_ddr = DDRC, .r_pin = PINC,
-	},
-	.portd = {
-		.name = 'D', .r_port = PORTD, .r_ddr = DDRD, .r_pin = PIND,
-	},
-	.porte = {
-		.name = 'E', .r_port = PORTE, .r_ddr = DDRE, .r_pin = PINE,
-	},
-	.portf = {
-		.name = 'F', .r_port = PORTF, .r_ddr = DDRF, .r_pin = PINF,
-	},
-	.portg = {
-		.name = 'G', .r_port = PORTG, .r_ddr = DDRG, .r_pin = PING,
-	},
-
-	.porth = {
-		.name = 'H', .r_port = PORTH, .r_ddr = DDRH, .r_pin = PINH,
-	},
-	.portj = {
-		.name = 'J', .r_port = PORTJ, .r_ddr = DDRJ, .r_pin = PINJ,
-	},
-	.portk = {
-		.name = 'K', .r_port = PORTK, .r_ddr = DDRK, .r_pin = PINK,
-	},
-	.portl = {
-		.name = 'L', .r_port = PORTL, .r_ddr = DDRL, .r_pin = PINL,
-	},
-
+	AVR_IOPORT_DECLARE(c, 'C', C),
+	AVR_IOPORT_DECLARE(d, 'D', D),
+	AVR_IOPORT_DECLARE(e, 'E', E),
+	AVR_IOPORT_DECLARE(f, 'F', F),
+	AVR_IOPORT_DECLARE(g, 'G', G),
+	AVR_IOPORT_DECLARE(h, 'H', H),
+	AVR_IOPORT_DECLARE(j, 'J', J),
+	AVR_IOPORT_DECLARE(k, 'K', K),
+	AVR_IOPORT_DECLARE(l, 'L', L),
 	.uart0 = {
 		.disabled = AVR_IO_REGBIT(PRR0,PRUSART0),
 		.name = '0',

--- a/simavr/cores/sim_mega1281.c
+++ b/simavr/cores/sim_mega1281.c
@@ -77,9 +77,7 @@ const struct mcu_t {
 		AVR_EXTINT_MEGA_DECLARE(6, 'E', PE6, B),
 		AVR_EXTINT_MEGA_DECLARE(7, 'E', PE7, B),
 	},
-	.porta = {
-		.name = 'A', .r_port = PORTA, .r_ddr = DDRA, .r_pin = PINA,
-	},
+	AVR_IOPORT_DECLARE(a, 'A', A),
 	.portb = {
 		.name = 'B', .r_port = PORTB, .r_ddr = DDRB, .r_pin = PINB,
 		.pcint = {
@@ -89,22 +87,11 @@ const struct mcu_t {
 		},
 		.r_pcint = PCMSK0,
 	},
-	.portc = {
-		.name = 'C', .r_port = PORTC, .r_ddr = DDRC, .r_pin = PINC,
-	},
-	.portd = {
-		.name = 'D', .r_port = PORTD, .r_ddr = DDRD, .r_pin = PIND,
-	},
-	.porte = {
-		.name = 'E', .r_port = PORTE, .r_ddr = DDRE, .r_pin = PINE,
-	},
-	.portf = {
-		.name = 'F', .r_port = PORTF, .r_ddr = DDRF, .r_pin = PINF,
-	},
-	.portg = {
-		.name = 'G', .r_port = PORTG, .r_ddr = DDRG, .r_pin = PING,
-	},
-
+	AVR_IOPORT_DECLARE(c, 'C', C),
+	AVR_IOPORT_DECLARE(d, 'D', D),
+	AVR_IOPORT_DECLARE(e, 'E', E),
+	AVR_IOPORT_DECLARE(f, 'F', F),
+	AVR_IOPORT_DECLARE(g, 'G', G),
 	.uart0 = {
 		.disabled = AVR_IO_REGBIT(PRR0,PRUSART0),
 		.name = '0',

--- a/simavr/cores/sim_mega128rfa1.c
+++ b/simavr/cores/sim_mega128rfa1.c
@@ -88,9 +88,7 @@ const struct mcu_t {
 		},
 		.r_pcint = PCMSK0,
 	},
-	.portd = {
-		.name = 'D', .r_port = PORTD, .r_ddr = DDRD, .r_pin = PIND,
-	},
+	AVR_IOPORT_DECLARE(d, 'D', D),
 	.porte = {
 		.name = 'E', .r_port = PORTE, .r_ddr = DDRE, .r_pin = PINE,
 		.pcint = {
@@ -100,12 +98,8 @@ const struct mcu_t {
 		},
 		.r_pcint = PCMSK1,
 	},
-	.portf = {
-		.name = 'F', .r_port = PORTF, .r_ddr = DDRF, .r_pin = PINF,
-	},
-	.portg = {
-		.name = 'G', .r_port = PORTG, .r_ddr = DDRG, .r_pin = PING,
-	},
+	AVR_IOPORT_DECLARE(f, 'F', F),
+	AVR_IOPORT_DECLARE(g, 'G', G),
 
 	.uart0 = {
 		.disabled = AVR_IO_REGBIT(PRR0,PRUSART0),

--- a/simavr/cores/sim_mega128rfr2.c
+++ b/simavr/cores/sim_mega128rfr2.c
@@ -114,9 +114,7 @@ const struct mcu_t {
 		},
 		.r_pcint = PCMSK0,
 	},
-	.portd = {
-		.name = 'D', .r_port = PORTD, .r_ddr = DDRD, .r_pin = PIND,
-	},
+	AVR_IOPORT_DECLARE(d, 'D', D),
 	.porte = {
 		.name = 'E', .r_port = PORTE, .r_ddr = DDRE, .r_pin = PINE,
 		.pcint = {
@@ -126,12 +124,8 @@ const struct mcu_t {
 		},
 		.r_pcint = PCMSK1,
 	},
-	.portf = {
-		.name = 'F', .r_port = PORTF, .r_ddr = DDRF, .r_pin = PINF,
-	},
-	.portg = {
-		.name = 'G', .r_port = PORTG, .r_ddr = DDRG, .r_pin = PING,
-	},
+	AVR_IOPORT_DECLARE(f, 'F', F),
+	AVR_IOPORT_DECLARE(g, 'G', G),
 
 	.uart0 = {
 		.disabled = AVR_IO_REGBIT(PRR0,PRUSART0),

--- a/simavr/cores/sim_mega169.c
+++ b/simavr/cores/sim_mega169.c
@@ -55,9 +55,7 @@ const struct mcu_t {
 	.extint = {
 		AVR_EXTINT_DECLARE(0, 'D', PD1),
 	},
-	.porta = {
-		.name = 'A', .r_port = PORTA, .r_ddr = DDRA, .r_pin = PINA,
-	},
+	AVR_IOPORT_DECLARE(a, 'A', A),
 	.portb = {
 		.name = 'B', .r_port = PORTB, .r_ddr = DDRB, .r_pin = PINB,  .r_pcint = PCMSK1,
 		.pcint = {
@@ -66,12 +64,8 @@ const struct mcu_t {
 			.vector = PCINT1_vect,
 		},
 	},
-	.portc = {
-		.name = 'C', .r_port = PORTC, .r_ddr = DDRC, .r_pin = PINC,
-	},
-	.portd = {
-		.name = 'D', .r_port = PORTD, .r_ddr = DDRD, .r_pin = PIND,
-	},
+	AVR_IOPORT_DECLARE(c, 'C', C),
+	AVR_IOPORT_DECLARE(d, 'D', D),
 	.porte = {
 		.name = 'E', .r_port = PORTE, .r_ddr = DDRE, .r_pin = PINE, .r_pcint = PCMSK0,
 		.pcint = {
@@ -80,12 +74,8 @@ const struct mcu_t {
 			.vector = PCINT0_vect,
 		},
 	},
-	.portf = {
-		.name = 'F', .r_port = PORTF, .r_ddr = DDRF, .r_pin = PINF,
-	},
-	.portg = {
-		.name = 'G', .r_port = PORTG, .r_ddr = DDRG, .r_pin = PING,
-	},
+	AVR_IOPORT_DECLARE(f, 'F', F),
+	AVR_IOPORT_DECLARE(g, 'G', G),
 
 	.uart0 = {
 		.name = '0',

--- a/simavr/cores/sim_mega2560.c
+++ b/simavr/cores/sim_mega2560.c
@@ -83,9 +83,7 @@ const struct mcu_t {
 		AVR_EXTINT_MEGA_DECLARE(6, 'E', PE6, B),
 		AVR_EXTINT_MEGA_DECLARE(7, 'E', PE7, B),
 	},
-	.porta = {
-		.name = 'A', .r_port = PORTA, .r_ddr = DDRA, .r_pin = PINA,
-	},
+	AVR_IOPORT_DECLARE(a, 'A', A),
 	.portb = {
 		.name = 'B', .r_port = PORTB, .r_ddr = DDRB, .r_pin = PINB,
 		.pcint = {
@@ -95,35 +93,15 @@ const struct mcu_t {
 		},
 		.r_pcint = PCMSK0,
 	},
-	.portc = {
-		.name = 'C', .r_port = PORTC, .r_ddr = DDRC, .r_pin = PINC,
-	},
-	.portd = {
-		.name = 'D', .r_port = PORTD, .r_ddr = DDRD, .r_pin = PIND,
-	},
-	.porte = {
-		.name = 'E', .r_port = PORTE, .r_ddr = DDRE, .r_pin = PINE,
-	},
-	.portf = {
-		.name = 'F', .r_port = PORTF, .r_ddr = DDRF, .r_pin = PINF,
-	},
-	.portg = {
-		.name = 'G', .r_port = PORTG, .r_ddr = DDRG, .r_pin = PING,
-	},
-
-	.porth = {
-		.name = 'H', .r_port = PORTH, .r_ddr = DDRH, .r_pin = PINH,
-	},
-	.portj = {
-		.name = 'J', .r_port = PORTJ, .r_ddr = DDRJ, .r_pin = PINJ,
-	},
-	.portk = {
-		.name = 'K', .r_port = PORTK, .r_ddr = DDRK, .r_pin = PINK,
-	},
-	.portl = {
-		.name = 'L', .r_port = PORTL, .r_ddr = DDRL, .r_pin = PINL,
-	},
-
+	AVR_IOPORT_DECLARE(c, 'C', C),
+	AVR_IOPORT_DECLARE(d, 'D', D),
+	AVR_IOPORT_DECLARE(e, 'E', E),
+	AVR_IOPORT_DECLARE(f, 'F', F),
+	AVR_IOPORT_DECLARE(g, 'G', G),
+	AVR_IOPORT_DECLARE(h, 'H', H),
+	AVR_IOPORT_DECLARE(j, 'J', J),
+	AVR_IOPORT_DECLARE(k, 'K', K),
+	AVR_IOPORT_DECLARE(l, 'L', L),
 	.uart0 = {
 		.disabled = AVR_IO_REGBIT(PRR0,PRUSART0),
 		.name = '0',

--- a/simavr/cores/sim_megax.h
+++ b/simavr/cores/sim_megax.h
@@ -90,19 +90,11 @@ const struct mcu_t SIM_CORENAME = {
 		AVR_EXTINT_DECLARE(1, 'D', PD3),
 	},
 #ifdef PORTA
-	.porta = {
-		.name = 'A', .r_port = PORTA, .r_ddr = DDRA, .r_pin = PINA,
-	},
+	AVR_IOPORT_DECLARE(a, 'A', A),
 #endif
-	.portb = {
-		.name = 'B', .r_port = PORTB, .r_ddr = DDRB, .r_pin = PINB,
-	},
-	.portc = {
-		.name = 'C', .r_port = PORTC, .r_ddr = DDRC, .r_pin = PINC,
-	},
-	.portd = {
-		.name = 'D', .r_port = PORTD, .r_ddr = DDRD, .r_pin = PIND,
-	},
+	AVR_IOPORT_DECLARE(b, 'B', B),
+	AVR_IOPORT_DECLARE(c, 'C', C),
+	AVR_IOPORT_DECLARE(d, 'D', D),
 	.uart = {
 	   // no PRUSART .disabled = AVR_IO_REGBIT(PRR,PRUSART0),
 		.name = '0',

--- a/simavr/cores/sim_tiny2313.c
+++ b/simavr/cores/sim_tiny2313.c
@@ -59,9 +59,7 @@ static const struct mcu_t {
 		AVR_EXTINT_TINY_DECLARE(0, 'D', 2, EIFR),
 		AVR_EXTINT_TINY_DECLARE(1, 'D', 3, EIFR),
 	},
-	.porta = {	// port A has no PCInts..
-		.name = 'A', .r_port = PORTA, .r_ddr = DDRA, .r_pin = PINA,
-	},
+	AVR_IOPORT_DECLARE(a, 'A', A), // port A has no PCInts..
 	.portb = {
 		.name = 'B',  .r_port = PORTB, .r_ddr = DDRB, .r_pin = PINB,
 		.pcint = {
@@ -71,9 +69,7 @@ static const struct mcu_t {
 		},
 		.r_pcint = PCMSK,
 	},
-	.portd = {	// port D has no PCInts..
-		.name = 'D', .r_port = PORTD, .r_ddr = DDRD, .r_pin = PIND,
-	},
+	AVR_IOPORT_DECLARE(d, 'D', D), // port D has no PCInts..
 	.uart = {
 		// no PRR register on the 2313
 		//.disabled = AVR_IO_REGBIT(PRR,PRUSART0),

--- a/simavr/sim/avr_ioport.h
+++ b/simavr/sim/avr_ioport.h
@@ -118,6 +118,10 @@ typedef struct avr_ioport_t {
 
 void avr_ioport_init(avr_t * avr, avr_ioport_t * port);
 
+#define AVR_IOPORT_DECLARE(_lname, _cname, _uname) \
+	.port ## _lname = { \
+		.name = _cname, .r_port = PORT ## _uname, .r_ddr = DDR ## _uname, .r_pin = PIN ## _uname, \
+	}
 
 #ifdef __cplusplus
 };


### PR DESCRIPTION
convert port sructure declarations to macro AVR_IOPORT_DECLARE.

```
modified:   simavr/cores/sim_90usb162.c
modified:   simavr/cores/sim_mega128.c
modified:   simavr/cores/sim_mega1280.c
modified:   simavr/cores/sim_mega1281.c
modified:   simavr/cores/sim_mega128rfa1.c
modified:   simavr/cores/sim_mega128rfr2.c
modified:   simavr/cores/sim_mega169.c
modified:   simavr/cores/sim_mega2560.c
modified:   simavr/cores/sim_megax.h
modified:   simavr/cores/sim_tiny2313.c
modified:   simavr/sim/avr_ioport.h
```
