### PR TITLE
cores: add spi declaration

### DIFF
--- a/simavr/cores/sim_90usb162.c
+++ b/simavr/cores/sim_90usb162.c
@@ -228,22 +228,7 @@ const struct mcu_t {
 			},
 		},
 	},
-	.spi = {
-
-		.r_spdr = SPDR,
-		.r_spcr = SPCR,
-		.r_spsr = SPSR,
-
-		.spe = AVR_IO_REGBIT(SPCR, SPE),
-		.mstr = AVR_IO_REGBIT(SPCR, MSTR),
-
-		.spr = { AVR_IO_REGBIT(SPCR, SPR0), AVR_IO_REGBIT(SPCR, SPR1), AVR_IO_REGBIT(SPSR, SPI2X) },
-		.spi = {
-			.enable = AVR_IO_REGBIT(SPCR, SPIE),
-			.raised = AVR_IO_REGBIT(SPSR, SPIF),
-			.vector = SPI_STC_vect,
-		},
-	},
+	AVR_SPI_DECLARE(0, 0),
 	.usb = {
 		.name='1',
 		.disabled=AVR_IO_REGBIT(PRR1, PRUSB),// bit in the PRR

--- a/simavr/cores/sim_mega128.c
+++ b/simavr/cores/sim_mega128.c
@@ -434,23 +434,7 @@ const struct mcu_t {
 			.vector = TIMER3_CAPT_vect,
 		},
 	},
-	.spi = {
-
-		.r_spdr = SPDR,
-		.r_spcr = SPCR,
-		.r_spsr = SPSR,
-
-		.spe = AVR_IO_REGBIT(SPCR, SPE),
-		.mstr = AVR_IO_REGBIT(SPCR, MSTR),
-
-		.spr = { AVR_IO_REGBIT(SPCR, SPR0), AVR_IO_REGBIT(SPCR, SPR1), AVR_IO_REGBIT(SPSR, SPI2X) },
-		.spi = {
-			.enable = AVR_IO_REGBIT(SPCR, SPIE),
-			.raised = AVR_IO_REGBIT(SPSR, SPIF),
-			.vector = SPI_STC_vect,
-		},
-	},
-	
+	AVR_SPI_DECLARE(0, 0),
 	.twi = {
 
 		.r_twcr = TWCR,

--- a/simavr/cores/sim_mega1280.c
+++ b/simavr/cores/sim_mega1280.c
@@ -716,24 +716,7 @@ const struct mcu_t {
 		},
 
 	},
-	.spi = {
-		.disabled = AVR_IO_REGBIT(PRR0,PRSPI),
-
-		.r_spdr = SPDR,
-		.r_spcr = SPCR,
-		.r_spsr = SPSR,
-
-		.spe = AVR_IO_REGBIT(SPCR, SPE),
-		.mstr = AVR_IO_REGBIT(SPCR, MSTR),
-
-		.spr = { AVR_IO_REGBIT(SPCR, SPR0), AVR_IO_REGBIT(SPCR, SPR1), AVR_IO_REGBIT(SPSR, SPI2X) },
-		.spi = {
-			.enable = AVR_IO_REGBIT(SPCR, SPIE),
-			.raised = AVR_IO_REGBIT(SPSR, SPIF),
-			.vector = SPI_STC_vect,
-		},
-	},
-
+	AVR_SPI_DECLARE(PRR0, PRSPI),
 	.twi = {
 
 		.r_twcr = TWCR,

--- a/simavr/cores/sim_mega1281.c
+++ b/simavr/cores/sim_mega1281.c
@@ -461,24 +461,7 @@ const struct mcu_t {
 			.vector = TIMER3_CAPT_vect,
 		},
 	},
-	.spi = {
-		.disabled = AVR_IO_REGBIT(PRR0,PRSPI),
-
-		.r_spdr = SPDR,
-		.r_spcr = SPCR,
-		.r_spsr = SPSR,
-
-		.spe = AVR_IO_REGBIT(SPCR, SPE),
-		.mstr = AVR_IO_REGBIT(SPCR, MSTR),
-
-		.spr = { AVR_IO_REGBIT(SPCR, SPR0), AVR_IO_REGBIT(SPCR, SPR1), AVR_IO_REGBIT(SPSR, SPI2X) },
-		.spi = {
-			.enable = AVR_IO_REGBIT(SPCR, SPIE),
-			.raised = AVR_IO_REGBIT(SPSR, SPIF),
-			.vector = SPI_STC_vect,
-		},
-	},
-
+	AVR_SPI_DECLARE(PRR0, PRSPI),
 	.twi = {
 
 		.r_twcr = TWCR,

--- a/simavr/cores/sim_mega128rfr2.c
+++ b/simavr/cores/sim_mega128rfr2.c
@@ -494,24 +494,7 @@ const struct mcu_t {
 			.vector = TIMER3_CAPT_vect,
 		},
 	},
-	.spi = {
-		.disabled = AVR_IO_REGBIT(PRR0,PRSPI),
-
-		.r_spdr = SPDR,
-		.r_spcr = SPCR,
-		.r_spsr = SPSR,
-
-		.spe = AVR_IO_REGBIT(SPCR, SPE),
-		.mstr = AVR_IO_REGBIT(SPCR, MSTR),
-
-		.spr = { AVR_IO_REGBIT(SPCR, SPR0), AVR_IO_REGBIT(SPCR, SPR1), AVR_IO_REGBIT(SPSR, SPI2X) },
-		.spi = {
-			.enable = AVR_IO_REGBIT(SPCR, SPIE),
-			.raised = AVR_IO_REGBIT(SPSR, SPIF),
-			.vector = SPI_STC_vect,
-		},
-	},
-
+	AVR_SPI_DECLARE(PRR0, PRSPI),
 	.twi = {
 
 		.r_twcr = TWCR,

--- a/simavr/cores/sim_mega169.c
+++ b/simavr/cores/sim_mega169.c
@@ -319,24 +319,7 @@ const struct mcu_t {
 			},
 		},
 	},
-	.spi = {
-		.disabled = AVR_IO_REGBIT(PRR,PRSPI),
-
-		.r_spdr = SPDR,
-		.r_spcr = SPCR,
-		.r_spsr = SPSR,
-
-		.spe = AVR_IO_REGBIT(SPCR, SPE),
-		.mstr = AVR_IO_REGBIT(SPCR, MSTR),
-
-		.spr = { AVR_IO_REGBIT(SPCR, SPR0), AVR_IO_REGBIT(SPCR, SPR1), AVR_IO_REGBIT(SPSR, SPI2X) },
-		.spi = {
-			.enable = AVR_IO_REGBIT(SPCR, SPIE),
-			.raised = AVR_IO_REGBIT(SPSR, SPIF),
-			.vector = SPI_STC_vect,
-		},
-	},
-
+	AVR_SPI_DECLARE(PRR, PRSPI),
 };
 
 static avr_t * make()

--- a/simavr/cores/sim_mega2560.c
+++ b/simavr/cores/sim_mega2560.c
@@ -718,24 +718,7 @@ const struct mcu_t {
 		},
 
 	},
-	.spi = {
-		.disabled = AVR_IO_REGBIT(PRR0,PRSPI),
-
-		.r_spdr = SPDR,
-		.r_spcr = SPCR,
-		.r_spsr = SPSR,
-
-		.spe = AVR_IO_REGBIT(SPCR, SPE),
-		.mstr = AVR_IO_REGBIT(SPCR, MSTR),
-
-		.spr = { AVR_IO_REGBIT(SPCR, SPR0), AVR_IO_REGBIT(SPCR, SPR1), AVR_IO_REGBIT(SPSR, SPI2X) },
-		.spi = {
-			 .enable = AVR_IO_REGBIT(SPCR, SPIE),
-			 .raised = AVR_IO_REGBIT(SPSR, SPIF),
-			 .vector = SPI_STC_vect,
-		},
-	},
-
+	AVR_SPI_DECLARE(PRR0, PRSPI),
 	.twi = {
 
 		.r_twcr = TWCR,

--- a/simavr/cores/sim_megax.h
+++ b/simavr/cores/sim_megax.h
@@ -288,23 +288,7 @@ const struct mcu_t SIM_CORENAME = {
 			},
 		},
 	},
-	.spi = {
-
-		.r_spdr = SPDR,
-		.r_spcr = SPCR,
-		.r_spsr = SPSR,
-
-		.spe = AVR_IO_REGBIT(SPCR, SPE),
-		.mstr = AVR_IO_REGBIT(SPCR, MSTR),
-
-		.spr = { AVR_IO_REGBIT(SPCR, SPR0), AVR_IO_REGBIT(SPCR, SPR1), AVR_IO_REGBIT(SPSR, SPI2X) },
-		.spi = {
-			.enable = AVR_IO_REGBIT(SPCR, SPIE),
-			.raised = AVR_IO_REGBIT(SPSR, SPIF),
-			.vector = SPI_STC_vect,
-		},
-	},
-	
+	AVR_SPI_DECLARE(0, 0),
 	.twi = {
 
 		.r_twcr = TWCR,

--- a/simavr/cores/sim_megax4.h
+++ b/simavr/cores/sim_megax4.h
@@ -462,24 +462,7 @@ const struct mcu_t SIM_CORENAME = {
 		}
 	},
 #endif
-	.spi = {
-		.disabled = AVR_IO_REGBIT(PRR0,PRSPI),
-
-		.r_spdr = SPDR,
-		.r_spcr = SPCR,
-		.r_spsr = SPSR,
-
-		.spe = AVR_IO_REGBIT(SPCR, SPE),
-		.mstr = AVR_IO_REGBIT(SPCR, MSTR),
-
-		.spr = { AVR_IO_REGBIT(SPCR, SPR0), AVR_IO_REGBIT(SPCR, SPR1), AVR_IO_REGBIT(SPSR, SPI2X) },
-		.spi = {
-			.enable = AVR_IO_REGBIT(SPCR, SPIE),
-			.raised = AVR_IO_REGBIT(SPSR, SPIF),
-			.vector = SPI_STC_vect,
-		},
-	},
-	
+	AVR_SPI_DECLARE(PRR0, PRSPI),
 	.twi = {
 		.disabled = AVR_IO_REGBIT(PRR0,PRTWI),
 

--- a/simavr/cores/sim_megax8.h
+++ b/simavr/cores/sim_megax8.h
@@ -336,24 +336,7 @@ const struct mcu_t SIM_CORENAME = {
 			}
 		}
 	},
-	.spi = {
-		.disabled = AVR_IO_REGBIT(PRR,PRSPI),
-
-		.r_spdr = SPDR,
-		.r_spcr = SPCR,
-		.r_spsr = SPSR,
-
-		.spe = AVR_IO_REGBIT(SPCR, SPE),
-		.mstr = AVR_IO_REGBIT(SPCR, MSTR),
-
-		.spr = { AVR_IO_REGBIT(SPCR, SPR0), AVR_IO_REGBIT(SPCR, SPR1), AVR_IO_REGBIT(SPSR, SPI2X) },
-		.spi = {
-			.enable = AVR_IO_REGBIT(SPCR, SPIE),
-			.raised = AVR_IO_REGBIT(SPSR, SPIF),
-			.vector = SPI_STC_vect,
-		},
-	},
-
+	AVR_SPI_DECLARE(PRR, PRSPI),
 	.twi = {
 		.disabled = AVR_IO_REGBIT(PRR,PRTWI),
 

--- a/simavr/cores/sim_megaxm1.h
+++ b/simavr/cores/sim_megaxm1.h
@@ -294,24 +294,7 @@ const struct mcu_t SIM_CORENAME = {
 			},
 		},
 	},
-	.spi = {
-		.disabled = AVR_IO_REGBIT(PRR,PRSPI),
-
-		.r_spdr = SPDR,
-		.r_spcr = SPCR,
-		.r_spsr = SPSR,
-
-		.spe = AVR_IO_REGBIT(SPCR, SPE),
-		.mstr = AVR_IO_REGBIT(SPCR, MSTR),
-
-		.spr = { AVR_IO_REGBIT(SPCR, SPR0), AVR_IO_REGBIT(SPCR, SPR1), AVR_IO_REGBIT(SPSR, SPI2X) },
-		.spi = {
-			.enable = AVR_IO_REGBIT(SPCR, SPIE),
-			.raised = AVR_IO_REGBIT(SPSR, SPIF),
-			.vector = SPI_STC_vect,
-		},
-	},
-
+	AVR_SPI_DECLARE(PRR, PRSPI),
 };
 #endif /* SIM_CORENAME */
 

--- a/simavr/sim/avr_spi.h
+++ b/simavr/sim/avr_spi.h
@@ -57,6 +57,25 @@ typedef struct avr_spi_t {
 
 void avr_spi_init(avr_t * avr, avr_spi_t * port);
 
+#define AVR_SPI_DECLARE(_prr, _prspi) \
+	.spi = { \
+		.disabled = AVR_IO_REGBIT(_prr, _prspi), \
+	\
+		.r_spdr = SPDR, \
+		.r_spcr = SPCR, \
+		.r_spsr = SPSR, \
+	\
+		.spe = AVR_IO_REGBIT(SPCR, SPE), \
+		.mstr = AVR_IO_REGBIT(SPCR, MSTR), \
+	\
+		.spr = { AVR_IO_REGBIT(SPCR, SPR0), AVR_IO_REGBIT(SPCR, SPR1), AVR_IO_REGBIT(SPSR, SPI2X) }, \
+		.spi = { \
+			.enable = AVR_IO_REGBIT(SPCR, SPIE), \
+			.raised = AVR_IO_REGBIT(SPSR, SPIF), \
+			.vector = SPI_STC_vect, \
+		}, \
+	}
+
 #ifdef __cplusplus
 };
 #endif


### PR DESCRIPTION
convert spi structure definitions to AVR_SPI_DECLARE

```
modified:   simavr/cores/sim_90usb162.c
modified:   simavr/cores/sim_mega128.c
modified:   simavr/cores/sim_mega1280.c
modified:   simavr/cores/sim_mega1281.c
modified:   simavr/cores/sim_mega128rfr2.c
modified:   simavr/cores/sim_mega169.c
modified:   simavr/cores/sim_mega2560.c
modified:   simavr/cores/sim_megax.h
modified:   simavr/cores/sim_megax4.h
modified:   simavr/cores/sim_megax8.h
modified:   simavr/cores/sim_megaxm1.h
modified:   simavr/sim/avr_spi.h
```
