### PR TITLE
cores: Adds missing external interrupt for m16/m32

### DIFF
--- a/simavr/cores/sim_megax.h
+++ b/simavr/cores/sim_megax.h
@@ -1,5 +1,5 @@
 /*
-	sim_mega128.c
+	sim_megax.h
 
 	Copyright 2008, 2009 Michel Pollet <buserror@gmail.com>
 
@@ -38,7 +38,7 @@ void mx_init(struct avr_t * avr);
 void mx_reset(struct avr_t * avr);
 
 /*
- * This is a template for all of the 8/32/64 devices, hopefully
+ * This is a template for all of the 8/16/32 devices, hopefully
  */
 struct mcu_t {
 	avr_t          core;
@@ -88,6 +88,9 @@ const struct mcu_t SIM_CORENAME = {
 	.extint = {
 		AVR_EXTINT_DECLARE(0, 'D', PD2),
 		AVR_EXTINT_DECLARE(1, 'D', PD3),
+#ifdef INT2
+		AVR_ASYNC_EXTINT_DECLARE(2, 'B', PB2),
+#endif
 	},
 #ifdef PORTA
 	.porta = {

--- a/simavr/sim/avr_extint.c
+++ b/simavr/sim/avr_extint.c
@@ -31,9 +31,16 @@ static void avr_extint_irq_notify(struct avr_irq_t * irq, uint32_t value, void *
 	avr_extint_t * p = (avr_extint_t *)param;
 	avr_t * avr = p->io.avr;
 
-	uint8_t mode = avr_regbit_get_array(avr, p->eint[irq->irq].isc, 2);
 	int up = !irq->value && value;
 	int down = irq->value && !value;
+
+	uint8_t isc_bits = p->eint[irq->irq + 1].isc->reg ? 2 : 1;
+	uint8_t mode = avr_regbit_get_array(avr, p->eint[irq->irq].isc, isc_bits);
+
+	// Asynchronous interrupts, eg int2 in m16, m32 etc. support only down/up
+	if (isc_bits == 1)
+		mode +=2;
+
 	switch (mode) {
 		case 0:
 			// unsupported

--- a/simavr/sim/avr_extint.h
+++ b/simavr/sim/avr_extint.h
@@ -4,6 +4,7 @@
 	External Interrupt Handling (for INT0-3)
 
 	Copyright 2008, 2009 Michel Pollet <buserror@gmail.com>
+	Copyright 2014 Doug Szumski <d.s.szumski@gmail.com>
 
  	This file is part of simavr.
 
@@ -75,6 +76,20 @@ void avr_extint_init(avr_t * avr, avr_extint_t * p);
 			.vector = { \
 				.enable = AVR_IO_REGBIT(EIMSK, INT##_index), \
 				.raised = AVR_IO_REGBIT(EIFR, INTF##_index), \
+				.vector = INT##_index##_vect, \
+			},\
+		}
+
+// Asynchronous External Interrupt, for example INT2 on the m16 and m32
+// Uses only 1 interrupt sense control bit
+#define AVR_ASYNC_EXTINT_DECLARE(_index, _portname, _portpin) \
+		.eint[_index] = { \
+			.port_ioctl = AVR_IOCTL_IOPORT_GETIRQ(_portname), \
+			.port_pin = _portpin, \
+			.isc = { AVR_IO_REGBIT(MCUCSR, ISC##_index) },\
+			.vector = { \
+				.enable = AVR_IO_REGBIT(GICR, INT##_index), \
+				.raised = AVR_IO_REGBIT(GIFR, INTF##_index), \
 				.vector = INT##_index##_vect, \
 			},\
 		}


### PR DESCRIPTION
> Async external interrupt (INT2) was missing on m16/32. Since unlike the others
>    this interrupt uses only 1 bit for sense control avr_extint.\* were modified to
>    support this new mode.
