### PR TITLE
sim_io: do not overwrite _avr_io_mux_write in avr_register_io_write

### DIFF
--- a/simavr/sim/sim_io.c
+++ b/simavr/sim/sim_io.c
@@ -131,6 +131,7 @@ avr_register_io_write(
 			}
 			avr->io_shared_io[no].io[d].param = param;
 			avr->io_shared_io[no].io[d].c = writep;
+			return;
 		}
 	}
 


### PR DESCRIPTION
After installing an _avr_io_mux_write in avr_register_io_write, the w.param and w.c values were overwritten with the original param and writep values. I added an early return to prevent this.
