### PR TITLE
uname -o fixes and allow AVR_ROOT and AVR_INC overrides

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -45,9 +45,9 @@ CORE_CFLAGS	= -nostdinc -DAVR_CORE=1
 
 ifeq (${shell uname}, Darwin)
 # gcc 4.2 from MacOS is really not up to scratch anymore 
-CC			= clang
-AVR_ROOT 	:= "/Applications/Arduino.app/Contents/Resources/Java/hardware/tools/avr/"
-AVR_INC 	:= ${AVR_ROOT}/avr-4/
+CC		= clang
+AVR_ROOT 	?= "/Applications/Arduino.app/Contents/Resources/Java/hardware/tools/avr/"
+AVR_INC 	?= ${AVR_ROOT}/avr-4/
 AVR 		:= ${AVR_ROOT}/bin/avr-
 # Thats for MacPorts libelf
 ifeq (${shell test -d /opt/local && echo Exists}, Exists)
@@ -64,7 +64,7 @@ AVR_INC 	:= ${AVR_ROOT}
 AVR 		:= avr-
 
 # FIXME uname -o doesn't work on bsd derivatives
-#WIN := ${shell uname -o}
+WIN := ${shell uname -o 2>/dev/null ; if [ $$? -ne 0 ] ; then uname -s; fi}
 
 ifeq (${WIN}, Msys)
 AVR_ROOT    := ${shell echo "${AVR32_HOME}" | tr '\\' '/'}

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,7 +1,7 @@
 
 boards_base=${wildcard board_*}
 # Remove simduino until FileMapping is implemented to work around missing mmap in Win32
-ifeq (${shell uname -o}, Msys)
+ifeq (${shell uname -o 2>/dev/null ; if [ $$? -ne 0 ] ; then uname -s; fi}, Msys)
 boards=${subst board_usb,,${subst board_simduino,,$(boards_base)}}
 else
 boards=$(boards_base)

--- a/examples/Makefile.opengl
+++ b/examples/Makefile.opengl
@@ -8,7 +8,7 @@ ifeq  (${UNAME}, Linux)
 CPPFLAGS	+= ${shell pkg-config --cflags glu}
 LDFLAGS 	+= ${shell pkg-config --libs glu} -lglut
 else
-ifeq (${shell uname -o}, Msys)
+ifeq (${shell uname -o 2>/dev/null ; if [ $$? -ne 0 ] ; then uname -s ; fi}, Msys)
 LDFLAGS 	+= -mwindows -lopengl32 -lfreeglut
 else
 CPPFLAGS	+= ${shell pkg-config --cflags glu glut} -DFREEBSD=1

--- a/simavr/Makefile
+++ b/simavr/Makefile
@@ -37,7 +37,7 @@ all:
 include ../Makefile.common
 
 cores	:= ${wildcard cores/*.c}
-sim		:= ${wildcard sim/sim_*.c} ${wildcard sim/avr_*.c}
+sim	:= ${wildcard sim/sim_*.c} ${wildcard sim/avr_*.c}
 sim_o 	:= ${patsubst sim/%.c, ${OBJ}/%.o, ${sim}}
 
 VPATH	= cores
@@ -82,12 +82,11 @@ ${OBJ}/${target}.elf	: ${OBJ}/${target}.o
 
 ${target}	: ${OBJ}/${target}.elf
 
-# FIXME uname -o doesn't work on BSD
-#ifeq (${shell uname -o}, Msys)
-#	ln -sf $< $@.exe
-#else
+ifeq (${shell uname -o 2>/dev/null; if [ $$? -ne 0 ] ; then uname -s ; fi}, Msys)
+	ln -sf $< $@.exe
+else
 	ln -sf $< $@
-#endif
+endif
  
 clean: clean-${OBJ}
 	rm -rf ${target} *.a *.so *.exe


### PR DESCRIPTION
Hi:

These changes hopefully address your uname -o problem. Basically, the change to the Makefiles changes:

```
WIN := ${shell uname -o}
```

to 

```
WIN := ${shell uname -o 2>/dev/null ; if [ $$? -ne 0 ] ; then uname -s; fi}
```

etc.

I also propose a change here:

```
AVR_ROOT        := "/Applications/Arduino.app/Contents/Resources/Java/hardware/tools/avr/"
AVR_INC         := ${AVR_ROOT}/avr-4/ 
```

to

```
AVR_ROOT        ?= "/Applications/Arduino.app/Contents/Resources/Java/hardware/tools/avr/"
AVR_INC         ?= ${AVR_ROOT}/avr-4/ 
```

This allows me to set AVR_ROOT and AVR_INC in the .make.options file without modifying your Makefile.common file. With the := operator, my changes were always overridden. Perhaps a note about the well kept secret .make.options file would also be helpful :)

These settings are working for me on a Mac Yosemite:

```
$ cat .make.options
V = 0
CFLAGS      += -I/usr/include -I/opt/local/include -I/opt/local/include/libelf
CFLAGS      += -Wno-deprecated
AVR_ROOT    = /usr/local/CrossPack-AVR
AVR_INC     = ${AVR_ROOT}/avr
```

There remains one unresolved problem however, with the compile of cores/sim_mega324.c.  The include file "avr/iom324.h has now been split into three files:

```
- avr/iom324a.h
- avr/iom324p.h
- avr/iom324pa.h
```

It looks to me at first blush that sim_mega324.c should be split into three versions but I am not yet familiar enough with this project to make that determination.

Thanks, Warren  ve3wwg@gmail.com
