### PR TITLE
Fix for cygwin compile

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -55,10 +55,12 @@ IPATH		+= /opt/local/include
 LFLAGS		= -L/opt/local/lib/
 endif
 else
+ifneq (${WIN}, Msys)
 LINUX_AVR_ROOTS := /usr/lib/avr /usr/avr /opt/cross/avr/avr /usr/local/avr
 AVR_ROOT := $(firstword $(wildcard $(LINUX_AVR_ROOTS)))
 ifeq (${AVR_ROOT},)
 $(error No avr-libc root directory found. Tried the following paths: $(LINUX_AVR_ROOTS))
+endif
 endif
 AVR_INC 	:= ${AVR_ROOT}
 AVR 		:= avr-

--- a/simavr/cores/sim_mega1280.c
+++ b/simavr/cores/sim_mega1280.c
@@ -246,6 +246,16 @@ const struct mcu_t {
 
 		.r_adcsrb = ADCSRB,
 		.adts = { AVR_IO_REGBIT(ADCSRB, ADTS0), AVR_IO_REGBIT(ADCSRB, ADTS1), AVR_IO_REGBIT(ADCSRB, ADTS2),},
+		.adts_op = {
+			[0] = avr_adts_free_running,
+			[1] = avr_adts_analog_comparator_0,
+			[2] = avr_adts_external_interrupt_0,
+			[3] = avr_adts_timer_0_compare_match_a,
+			[4] = avr_adts_timer_0_overflow,
+			[5] = avr_adts_timer_1_compare_match_b,
+			[6] = avr_adts_timer_1_overflow,
+			[7] = avr_adts_timer_1_capture_event,
+		},
 
 		.muxmode = {
 			[0] = AVR_ADC_SINGLE(0), [1] = AVR_ADC_SINGLE(1),

--- a/simavr/cores/sim_mega1281.c
+++ b/simavr/cores/sim_mega1281.c
@@ -174,6 +174,16 @@ const struct mcu_t {
 
 		.r_adcsrb = ADCSRB,
 		.adts = { AVR_IO_REGBIT(ADCSRB, ADTS0), AVR_IO_REGBIT(ADCSRB, ADTS1), AVR_IO_REGBIT(ADCSRB, ADTS2),},
+		.adts_op = {
+			[0] = avr_adts_free_running,
+			[1] = avr_adts_analog_comparator_0,
+			[2] = avr_adts_external_interrupt_0,
+			[3] = avr_adts_timer_0_compare_match_a,
+			[4] = avr_adts_timer_0_overflow,
+			[5] = avr_adts_timer_1_compare_match_b,
+			[6] = avr_adts_timer_1_overflow,
+			[7] = avr_adts_timer_1_capture_event,
+		},
 
 		.muxmode = {
 			[0] = AVR_ADC_SINGLE(0), [1] = AVR_ADC_SINGLE(1),

--- a/simavr/cores/sim_mega128rfa1.c
+++ b/simavr/cores/sim_mega128rfa1.c
@@ -188,6 +188,16 @@ const struct mcu_t {
 
 		.r_adcsrb = ADCSRB,
 		.adts = { AVR_IO_REGBIT(ADCSRB, ADTS0), AVR_IO_REGBIT(ADCSRB, ADTS1), AVR_IO_REGBIT(ADCSRB, ADTS2),},
+		.adts_op = {
+			[0] = avr_adts_free_running,
+			[1] = avr_adts_analog_comparator_0,
+			[2] = avr_adts_external_interrupt_0,
+			[3] = avr_adts_timer_0_compare_match_a,
+			[4] = avr_adts_timer_0_overflow,
+			[5] = avr_adts_timer_1_compare_match_b,
+			[6] = avr_adts_timer_1_overflow,
+			[7] = avr_adts_timer_1_capture_event,
+		},
 
 		.muxmode = {
 			[0] = AVR_ADC_SINGLE(0), [1] = AVR_ADC_SINGLE(1),

--- a/simavr/cores/sim_mega128rfr2.c
+++ b/simavr/cores/sim_mega128rfr2.c
@@ -214,6 +214,16 @@ const struct mcu_t {
 
 		.r_adcsrb = ADCSRB,
 		.adts = { AVR_IO_REGBIT(ADCSRB, ADTS0), AVR_IO_REGBIT(ADCSRB, ADTS1), AVR_IO_REGBIT(ADCSRB, ADTS2),},
+		.adts_op = {
+			[0] = avr_adts_free_running,
+			[1] = avr_adts_analog_comparator_0,
+			[2] = avr_adts_external_interrupt_0,
+			[3] = avr_adts_timer_0_compare_match_a,
+			[4] = avr_adts_timer_0_overflow,
+			[5] = avr_adts_timer_1_compare_match_b,
+			[6] = avr_adts_timer_1_overflow,
+			[7] = avr_adts_timer_1_capture_event,
+		},
 
 		.muxmode = {
 			[0] = AVR_ADC_SINGLE(0), [1] = AVR_ADC_SINGLE(1),

--- a/simavr/cores/sim_mega169.c
+++ b/simavr/cores/sim_mega169.c
@@ -128,6 +128,16 @@ const struct mcu_t {
 
 		.r_adcsrb = ADCSRB,
 		.adts = { AVR_IO_REGBIT(ADCSRB, ADTS0), AVR_IO_REGBIT(ADCSRB, ADTS1), AVR_IO_REGBIT(ADCSRB, ADTS2),},
+		.adts_op = {
+			[0] = avr_adts_free_running,
+			[1] = avr_adts_analog_comparator_0,
+			[2] = avr_adts_external_interrupt_0,
+			[3] = avr_adts_timer_0_compare_match_a,
+			[4] = avr_adts_timer_0_overflow,
+			[5] = avr_adts_timer_1_compare_match_b,
+			[6] = avr_adts_timer_1_overflow,
+			[7] = avr_adts_timer_1_capture_event,
+		},
 
 		.muxmode = {
 			[0] = AVR_ADC_SINGLE(0), [1] = AVR_ADC_SINGLE(1),

--- a/simavr/cores/sim_mega2560.c
+++ b/simavr/cores/sim_mega2560.c
@@ -248,6 +248,16 @@ const struct mcu_t {
 
 		.r_adcsrb = ADCSRB,
 		.adts = { AVR_IO_REGBIT(ADCSRB, ADTS0), AVR_IO_REGBIT(ADCSRB, ADTS1), AVR_IO_REGBIT(ADCSRB, ADTS2),},
+		.adts_op = {
+			[0] = avr_adts_free_running,
+			[1] = avr_adts_analog_comparator_0,
+			[2] = avr_adts_external_interrupt_0,
+			[3] = avr_adts_timer_0_compare_match_a,
+			[4] = avr_adts_timer_0_overflow,
+			[5] = avr_adts_timer_1_compare_match_b,
+			[6] = avr_adts_timer_1_overflow,
+			[7] = avr_adts_timer_1_capture_event,
+		},
 
 		.muxmode = {
 			 [0] = AVR_ADC_SINGLE(0), [1] = AVR_ADC_SINGLE(1),

--- a/simavr/cores/sim_megax8.h
+++ b/simavr/cores/sim_megax8.h
@@ -168,6 +168,16 @@ const struct mcu_t SIM_CORENAME = {
 
 		.r_adcsrb = ADCSRB,
 		.adts = { AVR_IO_REGBIT(ADCSRB, ADTS0), AVR_IO_REGBIT(ADCSRB, ADTS1), AVR_IO_REGBIT(ADCSRB, ADTS2),},
+		.adts_op = {
+			[0] = avr_adts_free_running,
+			[1] = avr_adts_analog_comparator_0,
+			[2] = avr_adts_external_interrupt_0,
+			[3] = avr_adts_timer_0_compare_match_a,
+			[4] = avr_adts_timer_0_overflow,
+			[5] = avr_adts_timer_1_compare_match_b,
+			[6] = avr_adts_timer_1_overflow,
+			[7] = avr_adts_timer_1_capture_event,
+		},
 
 		.muxmode = {
 			[0] = AVR_ADC_SINGLE(0), [1] = AVR_ADC_SINGLE(1),

--- a/simavr/cores/sim_megaxm1.h
+++ b/simavr/cores/sim_megaxm1.h
@@ -171,7 +171,23 @@ const struct mcu_t SIM_CORENAME = {
 		.r_adcl = ADCL,
 
 		.r_adcsrb = ADCSRB,
-		.adts = { AVR_IO_REGBIT(ADCSRB, ADTS0), AVR_IO_REGBIT(ADCSRB, ADTS1), AVR_IO_REGBIT(ADCSRB, ADTS2),},
+		.adts = { AVR_IO_REGBIT(ADCSRB, ADTS0), AVR_IO_REGBIT(ADCSRB, ADTS1), AVR_IO_REGBIT(ADCSRB, ADTS2), AVR_IO_REGBIT(ADCSRB, ADTS3),},
+		.adts_op = {
+			[0] = avr_adts_free_running,
+			[1] = avr_adts_external_interrupt_0,
+			[2] = avr_adts_timer_0_compare_match_a,
+			[3] = avr_adts_timer_0_overflow,
+			[4] = avr_adts_timer_1_compare_match_b,
+			[5] = avr_adts_timer_1_overflow,
+			[6] = avr_adts_timer_1_capture_event,
+			[7] = avr_adts_psc_module_0_sync_signal,
+			[8] = avr_adts_psc_module_1_sync_signal,
+			[9] = avr_adts_psc_module_2_sync_signal,
+			[10] = avr_adts_analog_comparator_0,
+			[11] = avr_adts_analog_comparator_1,
+			[12] = avr_adts_analog_comparator_2,
+			[13] = avr_adts_analog_comparator_3,
+		},
 
 		.muxmode = {
 			[0] = AVR_ADC_SINGLE(0), [1] = AVR_ADC_SINGLE(1),

--- a/simavr/cores/sim_tinyx4.h
+++ b/simavr/cores/sim_tinyx4.h
@@ -110,6 +110,16 @@ const struct mcu_t SIM_CORENAME = {
 
         .r_adcsrb = ADCSRB,
         .adts = { AVR_IO_REGBIT(ADCSRB, ADTS0), AVR_IO_REGBIT(ADCSRB, ADTS1), AVR_IO_REGBIT(ADCSRB, ADTS2),},
+        .adts_op = {
+          [0] = avr_adts_free_running,
+          [1] = avr_adts_analog_comparator_0,
+          [2] = avr_adts_external_interrupt_0,
+          [3] = avr_adts_timer_0_compare_match_a,
+          [4] = avr_adts_timer_0_overflow,
+          [5] = avr_adts_timer_1_compare_match_b,
+          [6] = avr_adts_timer_1_overflow,
+          [7] = avr_adts_timer_1_capture_event,
+        },
         .bin = AVR_IO_REGBIT(ADCSRB, BIN),
 
         .muxmode = {

--- a/simavr/cores/sim_tinyx5.h
+++ b/simavr/cores/sim_tinyx5.h
@@ -102,6 +102,16 @@ const struct mcu_t SIM_CORENAME = {
 
 		.r_adcsrb = ADCSRB,
 		.adts = { AVR_IO_REGBIT(ADCSRB, ADTS0), AVR_IO_REGBIT(ADCSRB, ADTS1), AVR_IO_REGBIT(ADCSRB, ADTS2),},
+		.adts_op = {
+			[0] = avr_adts_free_running,
+			[1] = avr_adts_analog_comparator_0,
+			[2] = avr_adts_external_interrupt_0,
+			[3] = avr_adts_timer_0_compare_match_a,
+			[4] = avr_adts_timer_0_overflow,
+			[5] = avr_adts_timer_0_compare_match_b,
+			[6] = avr_adts_pin_change_interrupt,
+		},
+		
 		.bin = AVR_IO_REGBIT(ADCSRB, BIN),
 		.ipr = AVR_IO_REGBIT(ADCSRA, IPR),
 

--- a/simavr/sim/avr_adc.c
+++ b/simavr/sim/avr_adc.c
@@ -25,6 +25,8 @@
 #include "sim_time.h"
 #include "avr_adc.h"
 
+static void avr_adc_write(struct avr_t * avr, avr_io_addr_t addr, uint8_t v, void * param);
+
 static avr_cycle_count_t avr_adc_int_raise(struct avr_t * avr, avr_cycle_count_t when, void * param)
 {
 	avr_adc_t * p = (avr_adc_t *)param;
@@ -34,6 +36,15 @@ static avr_cycle_count_t avr_adc_int_raise(struct avr_t * avr, avr_cycle_count_t
 		avr_regbit_clear(avr, p->adsc);
 		p->first = 0;
 		p->read_status = 0;
+		if( avr_regbit_get(avr, p->adate) )
+		{
+			uint8_t a = p->adsc.reg;
+			if( a )
+			{
+				uint8_t val = avr->data[a] | (1 << p->adsc.bit);
+				avr_adc_write(avr, a, val, param);
+			}
+		}
 	}
 	return 0;
 }

--- a/simavr/sim/avr_adc.h
+++ b/simavr/sim/avr_adc.h
@@ -80,6 +80,27 @@ enum {
 	ADC_VREF_V256	= 2560,
 };
 
+// ADC trigger sources
+typedef enum {
+	avr_adrs_invalid = 0,
+	avr_adts_free_running,
+	avr_adts_analog_comparator_0,
+	avr_adts_analog_comparator_1,
+	avr_adts_analog_comparator_2,
+	avr_adts_analog_comparator_3,
+	avr_adts_external_interrupt_0,
+	avr_adts_timer_0_compare_match_a,
+	avr_adts_timer_0_compare_match_b,
+	avr_adts_timer_0_overflow,
+	avr_adts_timer_1_compare_match_b,
+	avr_adts_timer_1_overflow,
+	avr_adts_timer_1_capture_event,
+	avr_adts_pin_change_interrupt,
+	avr_adts_psc_module_0_sync_signal,
+	avr_adts_psc_module_1_sync_signal,
+	avr_adts_psc_module_2_sync_signal,
+} avr_adts_type;
+
 typedef struct avr_adc_t {
 	avr_io_t		io;
 
@@ -101,7 +122,8 @@ typedef struct avr_adc_t {
 	uint8_t			r_adcl, r_adch;	// Data Registers
 
 	uint8_t			r_adcsrb;	// ADC Control and Status Register B
-	avr_regbit_t	adts[3];	// Timing Source
+	avr_regbit_t	adts[4];	// Timing Source
+	avr_adts_type	adts_op[16];    // ADTS type
 	avr_regbit_t 	bin;		// Bipolar Input Mode (tinyx5 have it)
 	avr_regbit_t 	ipr;		// Input Polarity Reversal (tinyx5 have it)
 

--- a/simavr/sim/avr_watchdog.c
+++ b/simavr/sim/avr_watchdog.c
@@ -103,13 +103,14 @@ static void avr_watchdog_write(avr_t * avr, avr_io_addr_t addr, uint8_t v, void 
 
 	uint8_t old_wde = avr_regbit_get(avr, p->wde);
 	uint8_t old_wdie = avr_regbit_get(avr, p->watchdog.enable);
-
+	uint8_t old_wdce = avr_regbit_get(avr, p->wdce);
+	
 	uint8_t was_enabled = (old_wde || old_wdie);
 
 	uint8_t old_v = avr->data[addr]; // allow gdb to see write...
 	avr_core_watch_write(avr, addr, v);
 
-	if (avr_regbit_get(avr, p->wdce)) {
+	if (old_wdce) {
 		uint8_t old_wdp = avr_regbit_get_array(avr, p->wdp, 4);
 
 		// wdrf (watchdog reset flag) must be cleared before wde can be cleared.

--- a/simavr/sim/sim_io.c
+++ b/simavr/sim/sim_io.c
@@ -223,9 +223,9 @@ avr_io_setirqs(
 				char * dst = buf;
 				// copy the 'flags' of the name out
 				const char * kind = io->irq_names[i];
-				while (isdigit(*kind))
+				while (isdigit((int)*kind))
 					*dst++ = *kind++;
-				while (!isalpha(*kind))
+				while (!isalpha((int)*kind))
 					*dst++ = *kind++;
 				// add avr name
 //				strcpy(dst, io->avr->mmcu);


### PR DESCRIPTION
Hi,

I need this patch for compiling Simavr on Cygwin.
The patch fixes 2 issues:
- The Linux version is handled in the "else" branch in Makefile.common. I don't know the reason why, so I added an "ifneq" condition to prevent "no avr-libc root dir" failure. Later in the make file Msys is handled correctly.
- In simavr -Werror is turned on and isalpha and isdigit dies. An additional (int) cast is required.

After adding the patches:
make WIN=Msys
works.

Not sure what this "WIN=Msys" means (currently this is how Makefile.common handles Windows builds), but at least it compiles.
