### PR TITLE
Implemented: ADC free running mode

### DIFF
--- a/simavr/cores/sim_mega1280.c
+++ b/simavr/cores/sim_mega1280.c
@@ -246,6 +246,16 @@ const struct mcu_t {
 
 		.r_adcsrb = ADCSRB,
 		.adts = { AVR_IO_REGBIT(ADCSRB, ADTS0), AVR_IO_REGBIT(ADCSRB, ADTS1), AVR_IO_REGBIT(ADCSRB, ADTS2),},
+		.adts_op = {
+			[0] = avr_adts_free_running,
+			[1] = avr_adts_analog_comparator_0,
+			[2] = avr_adts_external_interrupt_0,
+			[3] = avr_adts_timer_0_compare_match_a,
+			[4] = avr_adts_timer_0_overflow,
+			[5] = avr_adts_timer_1_compare_match_b,
+			[6] = avr_adts_timer_1_overflow,
+			[7] = avr_adts_timer_1_capture_event,
+		},
 
 		.muxmode = {
 			[0] = AVR_ADC_SINGLE(0), [1] = AVR_ADC_SINGLE(1),

--- a/simavr/cores/sim_mega1281.c
+++ b/simavr/cores/sim_mega1281.c
@@ -174,6 +174,16 @@ const struct mcu_t {
 
 		.r_adcsrb = ADCSRB,
 		.adts = { AVR_IO_REGBIT(ADCSRB, ADTS0), AVR_IO_REGBIT(ADCSRB, ADTS1), AVR_IO_REGBIT(ADCSRB, ADTS2),},
+		.adts_op = {
+			[0] = avr_adts_free_running,
+			[1] = avr_adts_analog_comparator_0,
+			[2] = avr_adts_external_interrupt_0,
+			[3] = avr_adts_timer_0_compare_match_a,
+			[4] = avr_adts_timer_0_overflow,
+			[5] = avr_adts_timer_1_compare_match_b,
+			[6] = avr_adts_timer_1_overflow,
+			[7] = avr_adts_timer_1_capture_event,
+		},
 
 		.muxmode = {
 			[0] = AVR_ADC_SINGLE(0), [1] = AVR_ADC_SINGLE(1),

--- a/simavr/cores/sim_mega128rfa1.c
+++ b/simavr/cores/sim_mega128rfa1.c
@@ -188,6 +188,16 @@ const struct mcu_t {
 
 		.r_adcsrb = ADCSRB,
 		.adts = { AVR_IO_REGBIT(ADCSRB, ADTS0), AVR_IO_REGBIT(ADCSRB, ADTS1), AVR_IO_REGBIT(ADCSRB, ADTS2),},
+		.adts_op = {
+			[0] = avr_adts_free_running,
+			[1] = avr_adts_analog_comparator_0,
+			[2] = avr_adts_external_interrupt_0,
+			[3] = avr_adts_timer_0_compare_match_a,
+			[4] = avr_adts_timer_0_overflow,
+			[5] = avr_adts_timer_1_compare_match_b,
+			[6] = avr_adts_timer_1_overflow,
+			[7] = avr_adts_timer_1_capture_event,
+		},
 
 		.muxmode = {
 			[0] = AVR_ADC_SINGLE(0), [1] = AVR_ADC_SINGLE(1),

--- a/simavr/cores/sim_mega128rfr2.c
+++ b/simavr/cores/sim_mega128rfr2.c
@@ -214,6 +214,16 @@ const struct mcu_t {
 
 		.r_adcsrb = ADCSRB,
 		.adts = { AVR_IO_REGBIT(ADCSRB, ADTS0), AVR_IO_REGBIT(ADCSRB, ADTS1), AVR_IO_REGBIT(ADCSRB, ADTS2),},
+		.adts_op = {
+			[0] = avr_adts_free_running,
+			[1] = avr_adts_analog_comparator_0,
+			[2] = avr_adts_external_interrupt_0,
+			[3] = avr_adts_timer_0_compare_match_a,
+			[4] = avr_adts_timer_0_overflow,
+			[5] = avr_adts_timer_1_compare_match_b,
+			[6] = avr_adts_timer_1_overflow,
+			[7] = avr_adts_timer_1_capture_event,
+		},
 
 		.muxmode = {
 			[0] = AVR_ADC_SINGLE(0), [1] = AVR_ADC_SINGLE(1),

--- a/simavr/cores/sim_mega169.c
+++ b/simavr/cores/sim_mega169.c
@@ -128,6 +128,16 @@ const struct mcu_t {
 
 		.r_adcsrb = ADCSRB,
 		.adts = { AVR_IO_REGBIT(ADCSRB, ADTS0), AVR_IO_REGBIT(ADCSRB, ADTS1), AVR_IO_REGBIT(ADCSRB, ADTS2),},
+		.adts_op = {
+			[0] = avr_adts_free_running,
+			[1] = avr_adts_analog_comparator_0,
+			[2] = avr_adts_external_interrupt_0,
+			[3] = avr_adts_timer_0_compare_match_a,
+			[4] = avr_adts_timer_0_overflow,
+			[5] = avr_adts_timer_1_compare_match_b,
+			[6] = avr_adts_timer_1_overflow,
+			[7] = avr_adts_timer_1_capture_event,
+		},
 
 		.muxmode = {
 			[0] = AVR_ADC_SINGLE(0), [1] = AVR_ADC_SINGLE(1),

--- a/simavr/cores/sim_mega2560.c
+++ b/simavr/cores/sim_mega2560.c
@@ -248,6 +248,16 @@ const struct mcu_t {
 
 		.r_adcsrb = ADCSRB,
 		.adts = { AVR_IO_REGBIT(ADCSRB, ADTS0), AVR_IO_REGBIT(ADCSRB, ADTS1), AVR_IO_REGBIT(ADCSRB, ADTS2),},
+		.adts_op = {
+			[0] = avr_adts_free_running,
+			[1] = avr_adts_analog_comparator_0,
+			[2] = avr_adts_external_interrupt_0,
+			[3] = avr_adts_timer_0_compare_match_a,
+			[4] = avr_adts_timer_0_overflow,
+			[5] = avr_adts_timer_1_compare_match_b,
+			[6] = avr_adts_timer_1_overflow,
+			[7] = avr_adts_timer_1_capture_event,
+		},
 
 		.muxmode = {
 			 [0] = AVR_ADC_SINGLE(0), [1] = AVR_ADC_SINGLE(1),

--- a/simavr/cores/sim_megax8.h
+++ b/simavr/cores/sim_megax8.h
@@ -168,6 +168,16 @@ const struct mcu_t SIM_CORENAME = {
 
 		.r_adcsrb = ADCSRB,
 		.adts = { AVR_IO_REGBIT(ADCSRB, ADTS0), AVR_IO_REGBIT(ADCSRB, ADTS1), AVR_IO_REGBIT(ADCSRB, ADTS2),},
+		.adts_op = {
+			[0] = avr_adts_free_running,
+			[1] = avr_adts_analog_comparator_0,
+			[2] = avr_adts_external_interrupt_0,
+			[3] = avr_adts_timer_0_compare_match_a,
+			[4] = avr_adts_timer_0_overflow,
+			[5] = avr_adts_timer_1_compare_match_b,
+			[6] = avr_adts_timer_1_overflow,
+			[7] = avr_adts_timer_1_capture_event,
+		},
 
 		.muxmode = {
 			[0] = AVR_ADC_SINGLE(0), [1] = AVR_ADC_SINGLE(1),

--- a/simavr/cores/sim_megaxm1.h
+++ b/simavr/cores/sim_megaxm1.h
@@ -171,7 +171,23 @@ const struct mcu_t SIM_CORENAME = {
 		.r_adcl = ADCL,
 
 		.r_adcsrb = ADCSRB,
-		.adts = { AVR_IO_REGBIT(ADCSRB, ADTS0), AVR_IO_REGBIT(ADCSRB, ADTS1), AVR_IO_REGBIT(ADCSRB, ADTS2),},
+		.adts = { AVR_IO_REGBIT(ADCSRB, ADTS0), AVR_IO_REGBIT(ADCSRB, ADTS1), AVR_IO_REGBIT(ADCSRB, ADTS2), AVR_IO_REGBIT(ADCSRB, ADTS3),},
+		.adts_op = {
+			[0] = avr_adts_free_running,
+			[1] = avr_adts_external_interrupt_0,
+			[2] = avr_adts_timer_0_compare_match_a,
+			[3] = avr_adts_timer_0_overflow,
+			[4] = avr_adts_timer_1_compare_match_b,
+			[5] = avr_adts_timer_1_overflow,
+			[6] = avr_adts_timer_1_capture_event,
+			[7] = avr_adts_psc_module_0_sync_signal,
+			[8] = avr_adts_psc_module_1_sync_signal,
+			[9] = avr_adts_psc_module_2_sync_signal,
+			[10] = avr_adts_analog_comparator_0,
+			[11] = avr_adts_analog_comparator_1,
+			[12] = avr_adts_analog_comparator_2,
+			[13] = avr_adts_analog_comparator_3,
+		},
 
 		.muxmode = {
 			[0] = AVR_ADC_SINGLE(0), [1] = AVR_ADC_SINGLE(1),

--- a/simavr/cores/sim_tinyx4.h
+++ b/simavr/cores/sim_tinyx4.h
@@ -110,6 +110,16 @@ const struct mcu_t SIM_CORENAME = {
 
         .r_adcsrb = ADCSRB,
         .adts = { AVR_IO_REGBIT(ADCSRB, ADTS0), AVR_IO_REGBIT(ADCSRB, ADTS1), AVR_IO_REGBIT(ADCSRB, ADTS2),},
+        .adts_op = {
+          [0] = avr_adts_free_running,
+          [1] = avr_adts_analog_comparator_0,
+          [2] = avr_adts_external_interrupt_0,
+          [3] = avr_adts_timer_0_compare_match_a,
+          [4] = avr_adts_timer_0_overflow,
+          [5] = avr_adts_timer_1_compare_match_b,
+          [6] = avr_adts_timer_1_overflow,
+          [7] = avr_adts_timer_1_capture_event,
+        },
         .bin = AVR_IO_REGBIT(ADCSRB, BIN),
 
         .muxmode = {

--- a/simavr/cores/sim_tinyx5.h
+++ b/simavr/cores/sim_tinyx5.h
@@ -102,6 +102,16 @@ const struct mcu_t SIM_CORENAME = {
 
 		.r_adcsrb = ADCSRB,
 		.adts = { AVR_IO_REGBIT(ADCSRB, ADTS0), AVR_IO_REGBIT(ADCSRB, ADTS1), AVR_IO_REGBIT(ADCSRB, ADTS2),},
+		.adts_op = {
+			[0] = avr_adts_free_running,
+			[1] = avr_adts_analog_comparator_0,
+			[2] = avr_adts_external_interrupt_0,
+			[3] = avr_adts_timer_0_compare_match_a,
+			[4] = avr_adts_timer_0_overflow,
+			[5] = avr_adts_timer_0_compare_match_b,
+			[6] = avr_adts_pin_change_interrupt,
+		},
+		
 		.bin = AVR_IO_REGBIT(ADCSRB, BIN),
 		.ipr = AVR_IO_REGBIT(ADCSRA, IPR),
 

--- a/simavr/sim/avr_adc.c
+++ b/simavr/sim/avr_adc.c
@@ -168,25 +168,21 @@ static void avr_adc_configure_trigger(struct avr_t * avr, avr_io_addr_t addr, ui
 		"psc_module_2_sync_signal",
 	};
 	
-	if( adate )
-	{
+	if( adate ) {
 		uint8_t adts = avr_regbit_get_array(avr, p->adts, ARRAY_SIZE(p->adts));
 		p->adts_mode = p->adts_op[adts];
 		
-		switch(p->adts_mode)
-		{
-			case avr_adts_free_running:
+		switch(p->adts_mode) {
+			case avr_adts_free_running: {
 				// do nothing at free running mode
-				break;
+			}	break;
 			// TODO: implement the other auto trigger modes
-			default:
+			default: {
 				AVR_LOG(avr, LOG_WARNING, "ADC: unimplemented auto trigger mode: %s\n", auto_trigger_names[p->adts_mode]);
 				p->adts_mode = avr_adts_none;
-				break;
+			}	break;
 		}
-	}
-	else
-	{
+	} else {
 		// TODO: remove previously configured auto triggers
 		p->adts_mode = avr_adts_none;
 	}
@@ -267,11 +263,9 @@ static void avr_adc_irq_notify(struct avr_irq_t * irq, uint32_t value, void * pa
 			if (avr_regbit_get(avr, p->adate)) {
 				// start a conversion only if it's not running
 				// otherwise ignore the trigger
-				if( ! avr_regbit_get(avr, p->adsc) )
-				{
+				if( ! avr_regbit_get(avr, p->adsc) ) {
 			  		uint8_t addr = p->adsc.reg;
-					if( addr )
-					{
+					if( addr ) {
 						uint8_t val = avr->data[addr] | (1 << p->adsc.bit);
 						// write ADSC to ADCSRA
 						avr_adc_write_adcsra(avr, addr, val, param);

--- a/simavr/sim/avr_adc.c
+++ b/simavr/sim/avr_adc.c
@@ -34,6 +34,8 @@ static avr_cycle_count_t avr_adc_int_raise(struct avr_t * avr, avr_cycle_count_t
 		avr_regbit_clear(avr, p->adsc);
 		p->first = 0;
 		p->read_status = 0;
+		if( p->adts_mode == avr_adts_free_running )
+			avr_raise_irq(p->io.irq + ADC_IRQ_IN_TRIGGER, 1);
 	}
 	return 0;
 }
@@ -139,8 +141,64 @@ static uint8_t avr_adc_read_h(struct avr_t * avr, avr_io_addr_t addr, void * par
 	}
 }
 
-static void avr_adc_write(struct avr_t * avr, avr_io_addr_t addr, uint8_t v, void * param)
+static void avr_adc_configure_trigger(struct avr_t * avr, avr_io_addr_t addr, uint8_t v, void * param)
 {
+	avr_adc_t * p = (avr_adc_t *)param;
+	
+	uint8_t adate = avr_regbit_get(avr, p->adate);
+	uint8_t old_adts = p->adts_mode;
+	
+	static char * auto_trigger_names[] = {
+		"none",
+		"free_running",
+		"analog_comparator_0",
+		"analog_comparator_1",
+		"analog_comparator_2",
+		"analog_comparator_3",
+		"external_interrupt_0",
+		"timer_0_compare_match_a",
+		"timer_0_compare_match_b",
+		"timer_0_overflow",
+		"timer_1_compare_match_b",
+		"timer_1_overflow",
+		"timer_1_capture_event",
+		"pin_change_interrupt",
+		"psc_module_0_sync_signal",
+		"psc_module_1_sync_signal",
+		"psc_module_2_sync_signal",
+	};
+	
+	if( adate )
+	{
+		uint8_t adts = avr_regbit_get_array(avr, p->adts, ARRAY_SIZE(p->adts));
+		p->adts_mode = p->adts_op[adts];
+		
+		switch(p->adts_mode)
+		{
+			case avr_adts_free_running:
+				// do nothing at free running mode
+				break;
+			// TODO: implement the other auto trigger modes
+			default:
+				AVR_LOG(avr, LOG_WARNING, "ADC: unimplemented auto trigger mode: %s\n", auto_trigger_names[p->adts_mode]);
+				p->adts_mode = avr_adts_none;
+				break;
+		}
+	}
+	else
+	{
+		// TODO: remove previously configured auto triggers
+		p->adts_mode = avr_adts_none;
+	}
+	
+	if( old_adts != p->adts_mode )
+		AVR_LOG(avr, LOG_TRACE, "ADC: auto trigger configured: %s\n", auto_trigger_names[p->adts_mode]);
+}
+
+static void avr_adc_write_adcsra(struct avr_t * avr, avr_io_addr_t addr, uint8_t v, void * param)
+{
+	avr_adc_configure_trigger(avr, addr, v, param);
+	
 	avr_adc_t * p = (avr_adc_t *)param;
 	uint8_t adsc = avr_regbit_get(avr, p->adsc);
 	uint8_t aden = avr_regbit_get(avr, p->aden);
@@ -188,6 +246,11 @@ static void avr_adc_write(struct avr_t * avr, avr_io_addr_t addr, uint8_t v, voi
 	avr_core_watch_write(avr, addr, v);
 }
 
+static void avr_adc_write_adcsrb(struct avr_t * avr, avr_io_addr_t addr, uint8_t v, void * param)
+{
+	avr_adc_configure_trigger(avr, addr, v, param);
+}
+
 static void avr_adc_irq_notify(struct avr_irq_t * irq, uint32_t value, void * param)
 {
 	avr_adc_t * p = (avr_adc_t *)param;
@@ -202,7 +265,18 @@ static void avr_adc_irq_notify(struct avr_irq_t * irq, uint32_t value, void * pa
 		}	break;
 		case ADC_IRQ_IN_TRIGGER: {
 			if (avr_regbit_get(avr, p->adate)) {
-				// start a conversion
+				// start a conversion only if it's not running
+				// otherwise ignore the trigger
+				if( ! avr_regbit_get(avr, p->adsc) )
+				{
+			  		uint8_t addr = p->adsc.reg;
+					if( addr )
+					{
+						uint8_t val = avr->data[addr] | (1 << p->adsc.bit);
+						// write ADSC to ADCSRA
+						avr_adc_write_adcsra(avr, addr, val, param);
+					}
+				}
 			}
 		}	break;
 	}
@@ -257,7 +331,8 @@ void avr_adc_init(avr_t * avr, avr_adc_t * p)
 	// allocate this module's IRQ
 	avr_io_setirqs(&p->io, AVR_IOCTL_ADC_GETIRQ, ADC_IRQ_COUNT, NULL);
 
-	avr_register_io_write(avr, p->r_adcsra, avr_adc_write, p);
+	avr_register_io_write(avr, p->r_adcsra, avr_adc_write_adcsra, p);
+	avr_register_io_write(avr, p->r_adcsrb, avr_adc_write_adcsrb, p);
 	avr_register_io_read(avr, p->r_adcl, avr_adc_read_l, p);
 	avr_register_io_read(avr, p->r_adch, avr_adc_read_h, p);
 }

--- a/simavr/sim/avr_adc.h
+++ b/simavr/sim/avr_adc.h
@@ -82,7 +82,7 @@ enum {
 
 // ADC trigger sources
 typedef enum {
-	avr_adrs_invalid = 0,
+	avr_adts_none = 0,
 	avr_adts_free_running,
 	avr_adts_analog_comparator_0,
 	avr_adts_analog_comparator_1,
@@ -124,6 +124,7 @@ typedef struct avr_adc_t {
 	uint8_t			r_adcsrb;	// ADC Control and Status Register B
 	avr_regbit_t	adts[4];	// Timing Source
 	avr_adts_type	adts_op[16];    // ADTS type
+	uint8_t		adts_mode;      // the extracted ADTS mode
 	avr_regbit_t 	bin;		// Bipolar Input Mode (tinyx5 have it)
 	avr_regbit_t 	ipr;		// Input Polarity Reversal (tinyx5 have it)
 

--- a/simavr/sim/avr_adc.h
+++ b/simavr/sim/avr_adc.h
@@ -80,6 +80,27 @@ enum {
 	ADC_VREF_V256	= 2560,
 };
 
+// ADC trigger sources
+typedef enum {
+	avr_adrs_invalid = 0,
+	avr_adts_free_running,
+	avr_adts_analog_comparator_0,
+	avr_adts_analog_comparator_1,
+	avr_adts_analog_comparator_2,
+	avr_adts_analog_comparator_3,
+	avr_adts_external_interrupt_0,
+	avr_adts_timer_0_compare_match_a,
+	avr_adts_timer_0_compare_match_b,
+	avr_adts_timer_0_overflow,
+	avr_adts_timer_1_compare_match_b,
+	avr_adts_timer_1_overflow,
+	avr_adts_timer_1_capture_event,
+	avr_adts_pin_change_interrupt,
+	avr_adts_psc_module_0_sync_signal,
+	avr_adts_psc_module_1_sync_signal,
+	avr_adts_psc_module_2_sync_signal,
+} avr_adts_type;
+
 typedef struct avr_adc_t {
 	avr_io_t		io;
 
@@ -101,7 +122,8 @@ typedef struct avr_adc_t {
 	uint8_t			r_adcl, r_adch;	// Data Registers
 
 	uint8_t			r_adcsrb;	// ADC Control and Status Register B
-	avr_regbit_t	adts[3];	// Timing Source
+	avr_regbit_t	adts[4];	// Timing Source
+	avr_adts_type	adts_op[16];    // ADTS type
 	avr_regbit_t 	bin;		// Bipolar Input Mode (tinyx5 have it)
 	avr_regbit_t 	ipr;		// Input Polarity Reversal (tinyx5 have it)
 


### PR DESCRIPTION
A patch for ADC free running mode.

It creates the complete framework for other autotrigger modes, such as analog comparator, timer 0 overflow,..

After applying this commit only the free running mode will work, but it won't be difficult adding new modes after this change.

I had to modify the core files as well, as ADTS is different on some AVR-s from the others.

Thanks,

    Csaba