### PR TITLE
Reconfigure fast pwm timer at OCRA write  if OCRA is the top

### DIFF
--- a/simavr/sim/avr_timer.c
+++ b/simavr/sim/avr_timer.c
@@ -316,6 +316,8 @@ static void avr_timer_write_ocr(struct avr_t * avr, avr_io_addr_t addr, uint8_t 
 		case avr_timer_wgm_pwm:
 			if (timer->mode.top != avr_timer_wgm_reg_ocra) {
 				avr_raise_irq(timer->io.irq + TIMER_IRQ_OUT_PWM0, _timer_get_ocr(timer, AVR_TIMER_COMPA));
+			} else {
+				avr_timer_reconfigure(timer); // if OCRA is the top, reconfigure needed
 			}
 			avr_raise_irq(timer->io.irq + TIMER_IRQ_OUT_PWM1, _timer_get_ocr(timer, AVR_TIMER_COMPB));
 			break;


### PR DESCRIPTION
If OCR0A is set before the timer configuration in fast pwm mode (WGM00, WGM01, WGM02), it works.
If OCR0A is set after, then the frequency is not changed.

Problematic code:
	TCCR0A = _BV(WGM00) | _BV(WGM01);
	TCCR0B = _BV(WGM02) | _BV(CS02);
	TCNT0 = 1;
	TIMSK0 |= _BV(TOIE0);
	OCR0A = 0xF9; // this is actually ignored, and timer runs as if it would be 0

The patch calls reconfigure in OCRA write if OCRA is the top.
The patch doesn't fix the very same problem with ICR1 for 16-bit timers. The issue with ICR1 modes are a bit more difficult, so I omitted in this patch.