### PR TITLE
Support IO register addresses >= 256

### DIFF
--- a/simavr/sim/sim_avr.h
+++ b/simavr/sim/sim_avr.h
@@ -55,7 +55,7 @@ enum {
 	R_SREG	= 32+0x3f,
 
 	// maximum number of IO registers, on normal AVRs
-	MAX_IOs	= 279,	// Bigger AVRs need more than 256-32 (mega1280)
+	MAX_IOs	= 280,	// Bigger AVRs need more than 256-32 (mega1280)
 };
 
 #define AVR_DATA_TO_IO(v) ((v) - 32)

--- a/simavr/sim/sim_core.c
+++ b/simavr/sim/sim_core.c
@@ -206,7 +206,7 @@ inline void _avr_sp_set(avr_t * avr, uint16_t sp)
  */
 static inline void _avr_set_ram(avr_t * avr, uint16_t addr, uint8_t v)
 {
-	if (addr < 256)
+	if (addr < MAX_IOs + 31)
 		_avr_set_r(avr, addr, v);
 	else
 		avr_core_watch_write(avr, addr, v);
@@ -224,7 +224,7 @@ static inline uint8_t _avr_get_ram(avr_t * avr, uint16_t addr)
 		 */
 		READ_SREG_INTO(avr, avr->data[R_SREG]);
 		
-	} else if (addr > 31 && addr < 256) {
+	} else if (addr > 31 && addr < 31 + MAX_IOs) {
 		uint8_t io = AVR_DATA_TO_IO(addr);
 		
 		if (avr->io[io].r.c)

--- a/simavr/sim/sim_core.c
+++ b/simavr/sim/sim_core.c
@@ -162,7 +162,7 @@ uint8_t avr_core_watch_read(avr_t *avr, uint16_t addr)
  * if it's an IO register (> 31) also (try to) call any callback that was
  * registered to track changes to that register.
  */
-static inline void _avr_set_r(avr_t * avr, uint8_t r, uint8_t v)
+static inline void _avr_set_r(avr_t * avr, uint16_t r, uint8_t v)
 {
 	REG_TOUCH(avr, r);
 
@@ -173,7 +173,7 @@ static inline void _avr_set_r(avr_t * avr, uint8_t r, uint8_t v)
 		SREG();
 	}
 	if (r > 31) {
-		uint8_t io = AVR_DATA_TO_IO(r);
+		avr_io_addr_t io = AVR_DATA_TO_IO(r);
 		if (avr->io[io].w.c)
 			avr->io[io].w.c(avr, r, v, avr->io[io].w.param);
 		else
@@ -225,7 +225,7 @@ static inline uint8_t _avr_get_ram(avr_t * avr, uint16_t addr)
 		READ_SREG_INTO(avr, avr->data[R_SREG]);
 		
 	} else if (addr > 31 && addr < 31 + MAX_IOs) {
-		uint8_t io = AVR_DATA_TO_IO(addr);
+		avr_io_addr_t io = AVR_DATA_TO_IO(addr);
 		
 		if (avr->io[io].r.c)
 			avr->data[addr] = avr->io[io].r.c(avr, addr, avr->io[io].r.param);

--- a/simavr/sim/sim_regbit.h
+++ b/simavr/sim/sim_regbit.h
@@ -42,7 +42,7 @@ extern "C" {
  */
 static inline uint8_t avr_regbit_set(avr_t * avr, avr_regbit_t rb)
 {
-	uint8_t a = rb.reg;
+	uint16_t a = rb.reg;
 	uint8_t m;
 
 	if (!a)
@@ -54,7 +54,7 @@ static inline uint8_t avr_regbit_set(avr_t * avr, avr_regbit_t rb)
 
 static inline uint8_t avr_regbit_setto(avr_t * avr, avr_regbit_t rb, uint8_t v)
 {
-	uint8_t a = rb.reg;
+	uint16_t a = rb.reg;
 	uint8_t m;
 
 	if (!a)
@@ -69,7 +69,7 @@ static inline uint8_t avr_regbit_setto(avr_t * avr, avr_regbit_t rb, uint8_t v)
  */
 static inline uint8_t avr_regbit_setto_raw(avr_t * avr, avr_regbit_t rb, uint8_t v)
 {
-	uint8_t a = rb.reg;
+	uint16_t a = rb.reg;
 	uint8_t m;
 
 	if (!a)
@@ -81,7 +81,7 @@ static inline uint8_t avr_regbit_setto_raw(avr_t * avr, avr_regbit_t rb, uint8_t
 
 static inline uint8_t avr_regbit_get(avr_t * avr, avr_regbit_t rb)
 {
-	uint8_t a = rb.reg;
+	uint16_t a = rb.reg;
 	if (!a)
 		return 0;
 	//uint8_t m = rb.mask << rb.bit;
@@ -95,7 +95,7 @@ static inline uint8_t avr_regbit_get(avr_t * avr, avr_regbit_t rb)
  */
 static inline uint8_t avr_regbit_from_value(avr_t * avr, avr_regbit_t rb, uint8_t value)
 {
-	uint8_t a = rb.reg;
+	uint16_t a = rb.reg;
 	if (!a)
 		return 0;
 	return (value >> rb.bit) & rb.mask;
@@ -106,7 +106,7 @@ static inline uint8_t avr_regbit_from_value(avr_t * avr, avr_regbit_t rb, uint8_
  */
 static inline uint8_t avr_regbit_get_raw(avr_t * avr, avr_regbit_t rb)
 {
-	uint8_t a = rb.reg;
+	uint16_t a = rb.reg;
 	if (!a)
 		return 0;
 	//uint8_t m = rb.mask << rb.bit;
@@ -115,7 +115,7 @@ static inline uint8_t avr_regbit_get_raw(avr_t * avr, avr_regbit_t rb)
 
 static inline uint8_t avr_regbit_clear(avr_t * avr, avr_regbit_t rb)
 {
-	uint8_t a = (rb.reg);
+	uint16_t a = rb.reg;
 	uint8_t m = rb.mask << rb.bit;
 	avr_core_watch_write(avr, a, avr->data[a] & ~m);
 	return avr->data[a];
@@ -133,7 +133,7 @@ static inline uint8_t avr_regbit_get_array(avr_t * avr, avr_regbit_t *rb, int co
 	int i;
 
 	for (i = 0; i < count; i++, rb++) if (rb->reg) {
-		uint8_t a = (rb->reg);
+		uint16_t a = rb->reg;
 		res |= ((avr->data[a] >> rb->bit) & rb->mask) << i;
 	}
 	return res;

--- a/tests/atmega2560_uart_echo.c
+++ b/tests/atmega2560_uart_echo.c
@@ -1,0 +1,127 @@
+/*
+	atmega88_uart_echo.c
+
+	This test case enables uart RX interupts, does a "printf" and then receive characters
+	via the interupt handler until it reaches a \r.
+
+	This tests the uart reception fifo system. It relies on the uart "irq" input and output
+	to be wired together (see simavr.c)
+ */
+
+#include <avr/io.h>
+#include <stdio.h>
+#include <avr/interrupt.h>
+#include <avr/eeprom.h>
+#include <avr/sleep.h>
+#include <util/delay.h>
+
+/*
+ * This demonstrate how to use the avr_mcu_section.h file
+ * The macro adds a section to the ELF file with useful
+ * information for the simulator
+ */
+#include "avr_mcu_section.h"
+AVR_MCU(F_CPU, "atmega2560");
+// tell simavr to listen to commands written in this (unused) register
+AVR_MCU_SIMAVR_COMMAND(&GPIOR0);
+AVR_MCU_SIMAVR_CONSOLE(&GPIOR1);
+
+/*
+ * This small section tells simavr to generate a VCD trace dump with changes to these
+ * registers.
+ * Opening it with gtkwave will show you the data being pumped out into the data register
+ * UDR0, and the UDRE0 bit being set, then cleared
+ */
+const struct avr_mmcu_vcd_trace_t _mytrace[]  _MMCU_ = {
+	{ AVR_MCU_VCD_SYMBOL("UDR3"), .what = (void*)&UDR3, },
+	{ AVR_MCU_VCD_SYMBOL("UDRE3"), .mask = (1 << UDRE3), .what = (void*)&UCSR3A, },
+	{ AVR_MCU_VCD_SYMBOL("GPIOR1"), .what = (void*)&GPIOR1, },
+};
+
+volatile uint8_t cnt = 0;
+volatile uint8_t done = 0;
+
+static int uart_putchar(char c, FILE *stream)
+{
+	uint8_t startcnt;
+	if (c == '\n')
+		uart_putchar('\r', stream);
+	loop_until_bit_is_set(UCSR3A, UDRE3);
+
+	startcnt = cnt;
+	UDR3 = c;
+//	_delay_us(100);
+
+	// Wait until we have received the character back
+	while(!done && cnt == startcnt)
+	{
+		UDR1 = 'a';
+		UDR1 = '\n';
+		sleep_cpu();
+	}
+
+	UDR1 = 'b';
+	UDR1 = '\n';
+
+	_delay_us(1000);
+
+	return 0;
+}
+
+static FILE mystdout = FDEV_SETUP_STREAM(uart_putchar, NULL,
+                                         _FDEV_SETUP_WRITE);
+
+volatile uint8_t bindex = 0;
+uint8_t buffer[80];
+
+ISR(USART3_RX_vect)
+{
+	UDR1 = 'c';
+	UDR1 = '\n';
+
+	uint8_t b = UDR3;
+	GPIOR1 = b; // for the trace file
+	buffer[bindex++] = b;
+	buffer[bindex] = 0;
+	cnt++;
+	if (b == '\n')
+		done++;
+//	sleep_cpu();
+}
+
+int main()
+{
+	stdout = &mystdout;
+
+	UCSR3C = (3 << UCSZ30); // 8 bits
+	// see http://www.nongnu.org/avr-libc/user-manual/group__util__setbaud.html
+#define BAUD 38400
+#include <util/setbaud.h>
+	UBRR3H = UBRRH_VALUE;
+	UBRR3L = UBRRL_VALUE;
+#if USE_2X
+	UCSR3A |= (1 << U2X3);
+#else
+	UCSR3A &= ~(1 << U2X3);
+#endif
+
+	// enable receiver & transmitter
+	UCSR3B |= (1 << RXCIE3) | (1 << RXEN3) | (1 << TXEN3);
+
+	// this tells simavr to start the trace
+	GPIOR0 = SIMAVR_CMD_VCD_START_TRACE;
+	sei();
+	printf("Hey there, this should be received back\n");
+	loop_until_bit_is_set(UCSR3A, UDRE3);
+
+	while (!done)
+		sleep_cpu();
+
+	cli();
+
+	printf("Received: %s", buffer);
+
+	// this quits the simulator, since interupts are off
+	// this is a "feature" that allows running tests cases and exit
+	sleep_cpu();
+}

--- a/tests/test_atmega2560_uart_echo.c
+++ b/tests/test_atmega2560_uart_echo.c
@@ -1,0 +1,22 @@
+#include "tests.h"
+#include "avr_uart.h"
+
+int main(int argc, char **argv) {
+	tests_init(argc, argv);
+
+	avr_t* avr = tests_init_avr("atmega2560_uart_echo.axf");
+	avr->log = LOG_TRACE;
+
+	avr_irq_t * src = avr_io_getirq(avr, AVR_IOCTL_UART_GETIRQ('3'), UART_IRQ_OUTPUT);
+	avr_irq_t * dst = avr_io_getirq(avr, AVR_IOCTL_UART_GETIRQ('3'), UART_IRQ_INPUT);
+	avr_connect_irq(src, dst);
+
+	static const char *expected =
+		"Hey there, this should be received back\r\n"
+		"Received: Hey there, this should be received back\r\r\n";
+
+	tests_assert_uart_receive_avr(avr, 10000000, expected, '3');
+
+	tests_success();
+	return 0;
+}


### PR DESCRIPTION
This PR introduces a unit test for UART3 usage on the ATmega2560, which first fails because UART3 resides at the end of the IO register space (UDR3 at 0x136) and the core wasn't able to handle these addresses.
It then fixes the issues in the core (mainly replacing 'uint8_t' by 'uint16_t' or 'avr_io_addr_t') and gets the test to pass.