### PR TITLE
adc: check r_adcsrb is valid before init

### DIFF
--- a/simavr/sim/avr_adc.c
+++ b/simavr/sim/avr_adc.c
@@ -326,7 +326,8 @@ void avr_adc_init(avr_t * avr, avr_adc_t * p)
 	avr_io_setirqs(&p->io, AVR_IOCTL_ADC_GETIRQ, ADC_IRQ_COUNT, NULL);
 
 	avr_register_io_write(avr, p->r_adcsra, avr_adc_write_adcsra, p);
-	avr_register_io_write(avr, p->r_adcsrb, avr_adc_write_adcsrb, p);
+	if (p->r_adcsrb)
+		avr_register_io_write(avr, p->r_adcsrb, avr_adc_write_adcsrb, p);
 	avr_register_io_read(avr, p->r_adcl, avr_adc_read_l, p);
 	avr_register_io_read(avr, p->r_adch, avr_adc_read_h, p);
 }


### PR DESCRIPTION
fix issue #118

	modified:   simavr/sim/avr_adc.c