### PR TITLE
make console output thread-safe (q&d)

### DIFF
--- a/simavr/sim/sim_avr.h
+++ b/simavr/sim/sim_avr.h
@@ -311,6 +311,13 @@ typedef struct avr_t {
 	// crashed even if not activated at startup
 	// if zero, the simulator will just exit() in case of a crash
 	int		gdb_port;
+
+	// buffer for console debugging output from register
+	struct {
+		char *	 buf;
+		uint32_t size;
+		uint32_t len;
+	} io_console_buffer;
 } avr_t;
 
 


### PR DESCRIPTION
Maybe just an idea, because it might leak memory now when avr_set_console_register() is called more than once, but it fixed my problem: Simulating multiple AVRs on a bus in threads, debugging output was garbled because of the static buffer before ...