### PR TITLE
sim_interrupts: fix FIFO move operation

### DIFF
--- a/simavr/sim/sim_interrupts.c
+++ b/simavr/sim/sim_interrupts.c
@@ -248,7 +248,7 @@ avr_service_interrupts(
 
 	// now move the one at the front of the fifo in the slot of
 	// the one we service
-	table->pending.buffer[mini % avr_int_pending_fifo_size] = 
+	table->pending.buffer[(table->pending.read + mini) % avr_int_pending_fifo_size] =
 			avr_int_pending_read(&table->pending);
 	avr_raise_irq(avr->interrupts.irq + AVR_INT_IRQ_PENDING,
 			avr_has_pending_interrupts(avr));


### PR DESCRIPTION
The variable 'mini' is a FIFO index, not a direct index into the buffer!
Add the current read pointer to fix the operation.

Fixes a regression introduced in 599733f261f94317489c2cc8751fb84fd604e6fa.