### PR TITLE
Update support for building with MacPorts

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -51,8 +51,17 @@ ifeq (${shell uname}, Darwin)
  AVR 		:= ${AVR_ROOT}/bin/avr-
  # Thats for MacPorts libelf
  ifeq (${shell test -d /opt/local && echo Exists}, Exists)
-  IPATH		+= /opt/local/include
-  LFLAGS		= -L/opt/local/lib/
+  ifneq (${shell test -d /opt/local/avr && echo Exists}, Exists)
+   $(error Please install avr-gcc: port install avr-gcc avr-libc)
+  endif
+  ifneq (${shell test -d /opt/local/include/libelf && echo Exists}, Exists)
+   $(error Please install libelf: port install libelf)
+  endif
+  CC		= clang
+  IPATH		+= /opt/local/include /opt/local/include/libelf
+  LFLAGS	= -L/opt/local/lib/
+  AVR_INC 	:= /opt/local/avr
+  AVR 		:= /opt/local/bin/avr-
  else
   # That's for Homebrew libelf and avr-gcc support
   ifeq (${shell test -d /usr/local/Cellar && echo Exists}, Exists)

--- a/simavr/sim/sim_gdb.c
+++ b/simavr/sim/sim_gdb.c
@@ -486,7 +486,7 @@ gdb_network_handler(
 		FD_SET(g->listen, &read_set);
 		max = g->listen + 1;
 	}
-	struct timeval timo = { 0, dosleep };	// short, but not too short interval
+	struct timeval timo = { dosleep / 1000000, dosleep % 1000000 };
 	int ret = select(max, &read_set, NULL, NULL, &timo);
 
 	if (ret == 0)


### PR DESCRIPTION
Updated Macports support based on Homebrew support.  Set correct paths
for MacPorts-provided avr-gcc and libelf.