### PR TITLE
Support sleep interval of 1s or greater in gdb

### DIFF
--- a/simavr/sim/sim_gdb.c
+++ b/simavr/sim/sim_gdb.c
@@ -486,7 +486,7 @@ gdb_network_handler(
 		FD_SET(g->listen, &read_set);
 		max = g->listen + 1;
 	}
-	struct timeval timo = { 0, dosleep };	// short, but not too short interval
+	struct timeval timo = { dosleep / 1000000, dosleep % 1000000 };
 	int ret = select(max, &read_set, NULL, NULL, &timo);
 
 	if (ret == 0)


### PR DESCRIPTION
When debugging in gdb, if a program uses the watchdog timer to sleep for a period of 1s or greater, an invalid timeval is passed to select() as the timeout.  At least on Mac OS X, this results in select() waiting forever.

This change splits the sleep interval into seconds and microseconds to create a valid timeval.
