### PR TITLE
Feature/ds1338 real time clock part

### DIFF
--- a/examples/board_ds1338/Makefile
+++ b/examples/board_ds1338/Makefile
@@ -1,0 +1,50 @@
+#	Copyright 2014 Doug Szumski <d.s.szumski@gmail.com>
+#	Copyright 2008-2011 Michel Pollet <buserror@gmail.com>
+#
+#	This file is part of simavr.
+#
+#	simavr is free software: you can redistribute it and/or modify
+#	it under the terms of the GNU General Public License as published by
+#	the Free Software Foundation, either version 3 of the License, or
+#	(at your option) any later version.
+#
+#	simavr is distributed in the hope that it will be useful,
+#	but WITHOUT ANY WARRANTY; without even the implied warranty of
+#	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#	GNU General Public License for more details.
+#
+#	You should have received a copy of the GNU General Public License
+#	along with simavr.  If not, see <http://www.gnu.org/licenses/>.
+
+target=	ds1338demo
+firm_src = ${wildcard at*${board}.c}
+firmware = ${firm_src:.c=.axf}
+simavr = ../../
+
+IPATH = .
+IPATH += ../parts
+IPATH += ${simavr}/include
+IPATH += ${simavr}/simavr/sim
+
+VPATH = .
+VPATH += ../parts
+
+LDFLAGS += -lpthread
+
+all: obj atmega32_ds1338.axf ${target}
+
+atmega32_ds1338.axf: atmega32_ds1338.c ds1338.c twimaster.c
+
+include ${simavr}/Makefile.common
+
+board = ${OBJ}/${target}.elf
+
+${board} : ${OBJ}/ac_input.o
+${board} : ${OBJ}/ds1338_virt.o
+${board} : ${OBJ}/${target}.o
+
+${target}: ${board}
+	@echo $@ done
+
+clean: clean-${OBJ}
+	rm -rf *.hex *.a *.axf ${target} *.vcd .*.swo .*.swp .*.swm .*.swn

--- a/examples/board_ds1338/atmega32_ds1338.c
+++ b/examples/board_ds1338/atmega32_ds1338.c
@@ -1,0 +1,93 @@
+/*
+ atmega32_ds1338.c
+
+ Copyright 2014 Doug Szumski <d.s.szumski@gmail.com>
+
+ This file is part of simavr.
+
+ simavr is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ simavr is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with simavr.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <avr/io.h>
+#include <avr/sleep.h>
+#include <avr/interrupt.h>
+#include <util/delay.h>
+
+#include <stdio.h>
+
+#undef F_CPU
+#define F_CPU 7380000
+
+#include "avr_mcu_section.h"
+AVR_MCU(F_CPU, "atmega32");
+
+#include "ds1338.h"
+#include "i2cmaster.h"
+
+volatile uint8_t update_flag;
+
+/*
+ * This demo consists of a DS1338 RTC connected via the TWI bus
+ * of an atmega32. The square wave output of the DS1338 is
+ * enabled, with the tick-rate set to 1HZ. This is then fed
+ * to pin D3 on the atmega32 which is configured to generate
+ * an interrupt on a rising edge. When the interrupt fires the
+ * time is read from the DS1338.
+ */
+
+int
+main()
+{
+	i2c_init();
+
+	/*
+	 * Demonstrate the virtual part functionality.
+	 */
+	ds1338_init();
+	ds1338_time_t time = {
+		.date = 31,
+		.day = 6,
+		.hours = 23,
+		.minutes = 59,
+		.month = 12,
+		.seconds = 56,
+		.year = 14,
+	};
+	ds1338_set_time(&time);
+
+	// Setup pin change interrupt for the square wave output
+	cli();
+	DDRD &= ~(1 << PD3);
+	// Fire INT1 on the rising edge
+	MCUCR |= (1 << ISC11) | (1 << ISC10);
+	GICR |= (1 << INT1);
+	sei();
+
+	while(time.seconds != 2)
+	{
+		if (update_flag) {
+			ds1338_get_time(&time);
+			update_flag = 0;
+		}
+	}
+
+	cli();
+	sleep_mode();
+
+}
+
+ISR (INT1_vect)
+{
+	update_flag = 1;
+}

--- a/examples/board_ds1338/ds1338.c
+++ b/examples/board_ds1338/ds1338.c
@@ -1,0 +1,114 @@
+/*
+ ds1338.c
+
+ DS1338 / DS1307 I2C clock module driver
+
+ Copyright 2012, 2014 Doug Szumski <d.s.szumski@gmail.com>
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+#include <stdint.h>
+
+#include "ds1338.h"
+#include "i2cmaster.h"
+
+static void
+ds1338_write(const uint8_t reg, const uint8_t data)
+{
+	i2c_start(DS1338_TWI_ADR + I2C_WRITE);
+	i2c_write(reg);
+	i2c_write(data);
+	i2c_stop();
+}
+
+static uint8_t
+ds1338_read(const uint8_t reg)
+{
+	i2c_start(DS1338_TWI_ADR + I2C_WRITE);
+	i2c_write(reg);
+	i2c_rep_start(DS1338_TWI_ADR + I2C_READ);
+	uint8_t data = i2c_readNak();
+	i2c_stop();
+
+	return data;
+}
+
+void
+ds1338_init(void)
+{
+	ds1338_write(DS1338_CONTROL, DS1338_CONTROL_SETTING);
+	// Set the CS bit to zero to enable clock
+	uint8_t data = ds1338_read(DS1338_SECONDS);
+	data &= ~(1 << DS1338_CH);
+	ds1338_write(DS1338_SECONDS, data);
+}
+
+void
+ds1338_get_time(ds1338_time_t * const time)
+{
+	uint8_t data = ds1338_read(DS1338_SECONDS);
+	time->seconds = 10 * ((data & 0b01110000) >> 4) + (data & 0x0F);
+
+	data = ds1338_read(DS1338_MINUTES);
+	time->minutes = UNPACK_BCD(data);
+
+	data = ds1338_read(DS1338_HOURS);
+	if (data & (1 << DS1338_12_24_HR))
+	{
+		// 12 hour mode
+		time->hours = 10 * ((data & 0b00010000) >> 4) + (data & 0x0F);
+		time->is_pm = data & (1 << DS1338_AM_PM);
+	} else {
+		// 24 hour mode
+		time->hours = 10 * ((data & 0b00110000) >> 4) + (data & 0x0F);
+	}
+
+	data = ds1338_read(DS1338_DAY);
+	// Shift day so that it's 0-6, not 1-7
+	time->day = data - 1;
+
+	data = ds1338_read(DS1338_DATE);
+	time->date = UNPACK_BCD(data);
+
+	data = ds1338_read(DS1338_MONTH);
+	time->month = UNPACK_BCD(data);
+
+	data = ds1338_read(DS1338_YEAR);
+	time->year = UNPACK_BCD(data);
+}
+
+void
+ds1338_set_time(const ds1338_time_t * const time)
+{
+	// Should always write zero to the CS bit to enable the clock
+	ds1338_write(DS1338_SECONDS, TO_BCD(time->seconds));
+	ds1338_write(DS1338_MINUTES, TO_BCD(time->minutes));
+
+	uint8_t hour_reg = ds1338_read(DS1338_HOURS);
+	// Wipe everything apart from the 12/24 hour bit
+	hour_reg &= ~(0b00111111);
+	if ((hour_reg & (1 << DS1338_12_24_HR)) && (time->is_pm)) {
+		// 12 hour mode and it's PM
+		hour_reg |= (1 << DS1338_AM_PM);
+	}
+	hour_reg |= TO_BCD(time->hours);
+	ds1338_write(DS1338_HOURS, hour_reg);
+
+	// Shift back day from 0-6 to 1-7.
+	ds1338_write(DS1338_DAY, time->day + 1);
+	ds1338_write(DS1338_DATE, TO_BCD(time->date));
+	ds1338_write(DS1338_MONTH, TO_BCD(time->month));
+	ds1338_write(DS1338_YEAR, TO_BCD(time->year));
+}

--- a/examples/board_ds1338/ds1338.h
+++ b/examples/board_ds1338/ds1338.h
@@ -1,0 +1,105 @@
+/*
+ ds1338.h
+
+ DS1338 / DS1307 I2C clock module driver
+
+ Copyright 2012, 2014 Doug Szumski <d.s.szumski@gmail.com>
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+/*
+ * A simple driver to interface with the DS1338. Should work with
+ * the pin compatible DS1307 too.
+ *
+ * TODO:
+ *
+ * > Read/write registers sequentially to/from an array.
+ * > Add a function to check the 'oscillator had a problem flag'
+ * > Add a function to configure the square wave output
+ * > Add a function to allow writing to additional NVRAM
+ * > Use bit fields to save RAM when storing time
+ */
+
+#ifndef DS1338_H
+#define DS1338_H
+
+/*
+ * Internal registers. Time is in BCD.
+ * See p10 of the DS1388 datasheet.
+ */
+#define DS1338_TWI_ADR		0xD0
+#define DS1338_SECONDS		0x00
+#define DS1338_MINUTES		0x01
+#define DS1338_HOURS		0x02
+#define DS1338_DAY		0x03
+#define DS1338_DATE		0x04
+#define DS1338_MONTH		0x05
+#define DS1338_YEAR		0x06
+#define DS1338_CONTROL		0x07
+
+/*
+ * Seconds register flag - oscillator is enabled when
+ * this is set to zero. Undefined on startup.
+ */
+#define DS1338_CH		7
+
+/*
+ * 12/24 hour select bit. When high clock is in 12 hour
+ * mode and the AM/PM bit is operational. When low the
+ * AM/PM bit becomes part of the tens counter for the
+ * 24 hour clock.
+ */
+#define DS1338_12_24_HR		6
+
+/*
+ * AM/PM flag for 12 hour mode. PM is high.
+ */
+#define DS1338_AM_PM		5
+
+// Control register settings: 1Hz square wave out
+#define DS1338_CONTROL_SETTING 0b10010000
+// 4kHz
+//#define DS1338_CONTROL_SETTING 0b10010001
+// 8 kHz
+//#define DS1338_CONTROL_SETTING 0b10010010
+// 32kHz
+//#define DS1338_CONTROL_SETTING 0b10010011
+
+// Generic BCD conversion. Don't use on seconds or hours.
+#define UNPACK_BCD(x) (((x) & 0x0F) + ((x) >> 4) * 10)
+#define TO_BCD(x) ((((x) / 10) << 4) + (x) % 10)
+
+typedef struct ds1338_time_t
+{
+	uint8_t seconds;
+	uint8_t minutes;
+	uint8_t hours;
+	uint8_t is_pm;
+	uint8_t day;		// Runs from 0-6
+	uint8_t date;
+	uint8_t month;
+	uint8_t year;
+} ds1338_time_t;
+
+void
+ds1338_init (void);
+
+void
+ds1338_get_time (ds1338_time_t * const time);
+
+void
+ds1338_set_time (const ds1338_time_t * const time);
+
+#endif //DS1338_H

--- a/examples/board_ds1338/ds1338demo.c
+++ b/examples/board_ds1338/ds1338demo.c
@@ -1,0 +1,83 @@
+/*
+ ds1338_demo.c
+
+ Copyright 2014 Doug Szumski <d.s.szumski@gmail.com>
+ Copyright 2011 Michel Pollet <buserror@gmail.com>
+
+ This file is part of simavr.
+
+ simavr is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ simavr is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with simavr.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <libgen.h>
+
+#include "sim_avr.h"
+#include "avr_twi.h"
+#include "sim_elf.h"
+#include "sim_gdb.h"
+#include "ds1338_virt.h"
+
+avr_t * avr = NULL;
+ds1338_virt_t ds1338_virt;
+
+int main(int argc, char *argv[])
+{
+	elf_firmware_t f;
+	const char * fname =  "atmega32_ds1338.axf";
+
+	printf("Firmware pathname is %s\n", fname);
+	elf_read_firmware(fname, &f);
+
+	printf("firmware %s f=%d mmcu=%s\n", fname, (int)f.frequency, f.mmcu);
+
+	avr = avr_make_mcu_by_name(f.mmcu);
+	if (!avr) {
+		fprintf(stderr, "%s: AVR '%s' not known\n", argv[0], f.mmcu);
+		exit(1);
+	}
+	avr_init(avr);
+	avr_load_firmware(avr, &f);
+
+	// Initialise our 'peripheral'
+	ds1338_virt_init(avr, &ds1338_virt);
+
+	// Hook up the TWI bus
+	ds1338_virt_attach_twi(&ds1338_virt, AVR_IOCTL_TWI_GETIRQ(0));
+
+	// Connect the square wave output
+	ds1338_pin_t wiring = {
+		.port = 'D',
+		.pin = 3
+	};
+	ds1338_virt_attach_square_wave_output (&ds1338_virt, &wiring);
+
+	// Even if not setup at startup, activate gdb if crashing
+	avr->gdb_port = 1234;
+	if (0) {
+		avr->state = cpu_Stopped;
+		avr_gdb_init(avr);
+	}
+
+	printf( "\nDS1338 demo launching:\n");
+
+	// Enable debug info
+	// TODO: Convert to logger?
+	ds1338_virt.verbose = 1;
+
+	int state = cpu_Running;
+	while ((state != cpu_Done) && (state != cpu_Crashed))
+		state = avr_run(avr);
+}

--- a/examples/board_ds1338/i2cmaster.h
+++ b/examples/board_ds1338/i2cmaster.h
@@ -1,0 +1,178 @@
+#ifndef _I2CMASTER_H
+#define _I2CMASTER_H   1
+/************************************************************************* 
+* Title:    C include file for the I2C master interface 
+*           (i2cmaster.S or twimaster.c)
+* Author:   Peter Fleury <pfleury@gmx.ch>  http://jump.to/fleury
+* File:     $Id: i2cmaster.h,v 1.10 2005/03/06 22:39:57 Peter Exp $
+* Software: AVR-GCC 3.4.3 / avr-libc 1.2.3
+* Target:   any AVR device
+* Usage:    see Doxygen manual
+**************************************************************************/
+
+#ifdef DOXYGEN
+/**
+ @defgroup pfleury_ic2master I2C Master library
+ @code #include <i2cmaster.h> @endcode
+  
+ @brief I2C (TWI) Master Software Library
+
+ Basic routines for communicating with I2C slave devices. This single master 
+ implementation is limited to one bus master on the I2C bus. 
+
+ This I2c library is implemented as a compact assembler software implementation of the I2C protocol 
+ which runs on any AVR (i2cmaster.S) and as a TWI hardware interface for all AVR with built-in TWI hardware (twimaster.c).
+ Since the API for these two implementations is exactly the same, an application can be linked either against the
+ software I2C implementation or the hardware I2C implementation.
+
+ Use 4.7k pull-up resistor on the SDA and SCL pin.
+ 
+ Adapt the SCL and SDA port and pin definitions and eventually the delay routine in the module 
+ i2cmaster.S to your target when using the software I2C implementation ! 
+ 
+ Adjust the  CPU clock frequence F_CPU in twimaster.c or in the Makfile when using the TWI hardware implementaion.
+
+ @note 
+    The module i2cmaster.S is based on the Atmel Application Note AVR300, corrected and adapted 
+    to GNU assembler and AVR-GCC C call interface.
+    Replaced the incorrect quarter period delays found in AVR300 with 
+    half period delays. 
+    
+ @author Peter Fleury pfleury@gmx.ch  http://jump.to/fleury
+
+ @par API Usage Example
+  The following code shows typical usage of this library, see example test_i2cmaster.c
+
+ @code
+
+ #include <i2cmaster.h>
+
+
+ #define Dev24C02  0xA2      // device address of EEPROM 24C02, see datasheet
+
+ int main(void)
+ {
+     unsigned char ret;
+
+     i2c_init();                             // initialize I2C library
+
+     // write 0x75 to EEPROM address 5 (Byte Write) 
+     i2c_start_wait(Dev24C02+I2C_WRITE);     // set device address and write mode
+     i2c_write(0x05);                        // write address = 5
+     i2c_write(0x75);                        // write value 0x75 to EEPROM
+     i2c_stop();                             // set stop conditon = release bus
+
+
+     // read previously written value back from EEPROM address 5 
+     i2c_start_wait(Dev24C02+I2C_WRITE);     // set device address and write mode
+
+     i2c_write(0x05);                        // write address = 5
+     i2c_rep_start(Dev24C02+I2C_READ);       // set device address and read mode
+
+     ret = i2c_readNak();                    // read one byte from EEPROM
+     i2c_stop();
+
+     for(;;);
+ }
+ @endcode
+
+*/
+#endif /* DOXYGEN */
+
+/**@{*/
+
+#if (__GNUC__ * 100 + __GNUC_MINOR__) < 304
+#error "This library requires AVR-GCC 3.4 or later, update to newer AVR-GCC compiler !"
+#endif
+
+#include <avr/io.h>
+
+/** defines the data direction (reading from I2C device) in i2c_start(),i2c_rep_start() */
+#define I2C_READ    1
+
+/** defines the data direction (writing to I2C device) in i2c_start(),i2c_rep_start() */
+#define I2C_WRITE   0
+
+
+/**
+ @brief initialize the I2C master interace. Need to be called only once 
+ @param  void
+ @return none
+ */
+extern void i2c_init(void);
+
+
+/** 
+ @brief Terminates the data transfer and releases the I2C bus 
+ @param void
+ @return none
+ */
+extern void i2c_stop(void);
+
+
+/** 
+ @brief Issues a start condition and sends address and transfer direction 
+  
+ @param    addr address and transfer direction of I2C device
+ @retval   0   device accessible 
+ @retval   1   failed to access device 
+ */
+extern unsigned char i2c_start(unsigned char addr);
+
+
+/**
+ @brief Issues a repeated start condition and sends address and transfer direction 
+
+ @param   addr address and transfer direction of I2C device
+ @retval  0 device accessible
+ @retval  1 failed to access device
+ */
+extern unsigned char i2c_rep_start(unsigned char addr);
+
+
+/**
+ @brief Issues a start condition and sends address and transfer direction 
+   
+ If device is busy, use ack polling to wait until device ready 
+ @param    addr address and transfer direction of I2C device
+ @return   none
+ */
+extern void i2c_start_wait(unsigned char addr);
+
+ 
+/**
+ @brief Send one byte to I2C device
+ @param    data  byte to be transfered
+ @retval   0 write successful
+ @retval   1 write failed
+ */
+extern unsigned char i2c_write(unsigned char data);
+
+
+/**
+ @brief    read one byte from the I2C device, request more data from device 
+ @return   byte read from I2C device
+ */
+extern unsigned char i2c_readAck(void);
+
+/**
+ @brief    read one byte from the I2C device, read is followed by a stop condition 
+ @return   byte read from I2C device
+ */
+extern unsigned char i2c_readNak(void);
+
+/** 
+ @brief    read one byte from the I2C device
+ 
+ Implemented as a macro, which calls either i2c_readAck or i2c_readNak
+ 
+ @param    ack 1 send ack, request more data from device<br>
+               0 send nak, read is followed by a stop condition 
+ @return   byte read from I2C device
+ */
+extern unsigned char i2c_read(unsigned char ack);
+#define i2c_read(ack)  (ack) ? i2c_readAck() : i2c_readNak(); 
+
+
+/**@}*/
+#endif

--- a/examples/board_ds1338/twimaster.c
+++ b/examples/board_ds1338/twimaster.c
@@ -1,0 +1,204 @@
+/*************************************************************************
+* Title:    I2C master library using hardware TWI interface
+* Author:   Peter Fleury <pfleury@gmx.ch>  http://jump.to/fleury
+* File:     $Id: twimaster.c,v 1.3 2005/07/02 11:14:21 Peter Exp $
+* Software: AVR-GCC 3.4.3 / avr-libc 1.2.3
+* Target:   any AVR device with hardware TWI 
+* Usage:    API compatible with I2C Software Library i2cmaster.h
+**************************************************************************/
+#include <inttypes.h>
+#include <compat/twi.h>
+#include <util/delay.h>
+
+#include "i2cmaster.h"
+
+
+/* define CPU frequency in Mhz here if not defined in Makefile */
+#ifndef F_CPU
+#define F_CPU 7372800UL
+#endif
+
+/* I2C clock in Hz */
+#define SCL_CLOCK  100000L
+
+
+/*************************************************************************
+ Initialization of the I2C bus interface. Need to be called only once
+*************************************************************************/
+void i2c_init(void)
+{
+  /* initialize TWI clock: 100 kHz clock, TWPS = 0 => prescaler = 1 */
+  
+  TWSR |= (1 << TWPS0);                         /* no prescaler */
+  TWBR = ((F_CPU/SCL_CLOCK)-16)/(2*4);  /* must be > 10 for stable operation */
+
+}/* i2c_init */
+
+
+/*************************************************************************	
+  Issues a start condition and sends address and transfer direction.
+  return 0 = device accessible, 1= failed to access device
+*************************************************************************/
+unsigned char i2c_start(unsigned char address)
+{
+    uint8_t   twst;
+
+	// send START condition
+	TWCR = (1<<TWINT) | (1<<TWSTA) | (1<<TWEN);
+
+	// wait until transmission completed
+	while(!(TWCR & (1<<TWINT)));
+
+	// check value of TWI Status Register. Mask prescaler bits.
+	twst = TW_STATUS & 0xF8;
+	if ( (twst != TW_START) && (twst != TW_REP_START)) return 1;
+
+	// send device address
+	TWDR = address;
+	TWCR = (1<<TWINT) | (1<<TWEN);
+
+	// wail until transmission completed and ACK/NACK has been received
+	while(!(TWCR & (1<<TWINT)));
+
+	// check value of TWI Status Register. Mask prescaler bits.
+	twst = TW_STATUS & 0xF8;
+	if ( (twst != TW_MT_SLA_ACK) && (twst != TW_MR_SLA_ACK) ) return 1;
+
+	return 0;
+
+}/* i2c_start */
+
+
+/*************************************************************************
+ Issues a start condition and sends address and transfer direction.
+ If device is busy, use ack polling to wait until device is ready
+ 
+ FIXME: If device doesn't exist stays in an infinite loop
+
+ Input:   address and transfer direction of I2C device
+*************************************************************************/
+void i2c_start_wait(unsigned char address)
+{
+    uint8_t   twst;
+
+
+    while ( 1 )
+    {
+	    // send START condition
+	    TWCR = (1<<TWINT) | (1<<TWSTA) | (1<<TWEN);
+    
+    	// wait until transmission completed
+    	while(!(TWCR & (1<<TWINT)));
+    
+    	// check value of TWI Status Register. Mask prescaler bits.
+    	twst = TW_STATUS & 0xF8;
+    	if ( (twst != TW_START) && (twst != TW_REP_START)) continue;
+    
+    	// send device address
+    	TWDR = address;
+    	TWCR = (1<<TWINT) | (1<<TWEN);
+    
+    	// wail until transmission completed
+    	while(!(TWCR & (1<<TWINT)));
+
+    	// check value of TWI Status Register. Mask prescaler bits.
+    	twst = TW_STATUS & 0xF8;
+    	if ( (twst == TW_MT_SLA_NACK )||(twst ==TW_MR_DATA_NACK) ) 
+    	{    	    
+    	    /* device busy, send stop condition to terminate write operation */
+	        TWCR = (1<<TWINT) | (1<<TWEN) | (1<<TWSTO);
+
+	        // wait until stop condition is executed and bus released
+	        while(TWCR & (1<<TWSTO));
+    	    continue;
+    	}
+    	break;
+     }
+
+}/* i2c_start_wait */
+
+
+/*************************************************************************
+ Issues a repeated start condition and sends address and transfer direction 
+
+ Input:   address and transfer direction of I2C device
+ 
+ Return:  0 device accessible
+          1 failed to access device
+*************************************************************************/
+unsigned char i2c_rep_start(unsigned char address)
+{
+    return i2c_start( address );
+
+}/* i2c_rep_start */
+
+
+/*************************************************************************
+ Terminates the data transfer and releases the I2C bus
+*************************************************************************/
+void i2c_stop(void)
+{
+    /* send stop condition */
+	TWCR = (1<<TWINT) | (1<<TWEN) | (1<<TWSTO);
+	
+	// wait until stop condition is executed and bus released
+	while(TWCR & (1<<TWSTO));
+
+}/* i2c_stop */
+
+
+/*************************************************************************
+  Send one byte to I2C device
+  
+  Input:    byte to be transfered
+  Return:   0 write successful 
+            1 write failed
+*************************************************************************/
+unsigned char i2c_write( unsigned char data )
+{	
+    uint8_t   twst;
+    
+	// send data to the previously addressed device
+	TWDR = data;
+	TWCR = (1<<TWINT) | (1<<TWEN);
+
+	// wait until transmission completed
+	while(!(TWCR & (1<<TWINT)));
+
+	// check value of TWI Status Register. Mask prescaler bits
+	twst = TW_STATUS & 0xF8;
+	if( twst != TW_MT_DATA_ACK) return 1;
+	return 0;
+
+}/* i2c_write */
+
+
+/*************************************************************************
+ Read one byte from the I2C device, request more data from device 
+ 
+ Return:  byte read from I2C device
+*************************************************************************/
+unsigned char i2c_readAck(void)
+{
+	TWCR = (1<<TWINT) | (1<<TWEN) | (1<<TWEA);
+	while(!(TWCR & (1<<TWINT)));    
+
+    return TWDR;
+
+}/* i2c_readAck */
+
+
+/*************************************************************************
+ Read one byte from the I2C device, read is followed by a stop condition 
+ 
+ Return:  byte read from I2C device
+*************************************************************************/
+unsigned char i2c_readNak(void)
+{
+	TWCR = (1<<TWINT) | (1<<TWEN);
+	while(!(TWCR & (1<<TWINT)));
+    //while(!(TWCR ));
+	//_delay_ms(100);
+    return TWDR;
+
+}/* i2c_readNak */

--- a/examples/parts/ds1338_virt.c
+++ b/examples/parts/ds1338_virt.c
@@ -1,0 +1,501 @@
+/*
+	ds1338_virt.c
+
+	Copyright 2014 Doug Szumski <d.s.szumski@gmail.com>
+
+	Based on i2c_eeprom example by:
+
+	Copyright 2008, 2009 Michel Pollet <buserror@gmail.com>
+
+	This file is part of simavr.
+
+	simavr is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	simavr is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with simavr.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "avr_twi.h"
+#include "ds1338_virt.h"
+#include "sim_time.h"
+
+
+/*
+ * Increment the ds1338 register address.
+ */
+static void
+ds1338_virt_incr_addr(ds1338_virt_t * const p)
+{
+	if (p->reg_addr < sizeof(p->nvram)) {
+		p->reg_addr++;
+	} else {
+		// TODO Check if this wraps, or if it just stops incrementing
+		p->reg_addr = 0;
+	}
+}
+
+/*
+ * Update the system behaviour after a control register is written to.
+ */
+static void
+ds1338_virt_update(const ds1338_virt_t * const p)
+{
+	// The address of the register which was just updated
+	switch (p->reg_addr)
+	{
+		case DS1338_VIRT_SECONDS:
+			if (ds1338_get_flag(p->nvram[p->reg_addr], DS1338_VIRT_CH) == 0) {
+				printf("DS1338 clock ticking\n");
+			} else {
+				printf("DS1338 clock stopped\n");
+			}
+			break;
+		case DS1338_VIRT_CONTROL:
+			printf("DS1338 control register updated\n");
+			// TODO: Check if changing the prescaler resets the clock counter
+			// and if so do it here?
+			break;
+		default:
+			// No control register updated
+			return;
+	}
+}
+
+/*
+ * Calculate days in month given the year. The year should be specified
+ * in 4 digit format.
+ */
+static uint8_t
+ds1338_virt_days_in_month(uint8_t month, uint16_t year) {
+
+	uint8_t is_leap_year = 1;
+	if ((year & 3) == 0 && ((year % 25) != 0 || (year & 15) == 0))
+		is_leap_year = 0;
+
+	uint8_t days;
+	if (month == 2)
+		days = 28 + is_leap_year;
+	else
+		days = 31 - (month - 1) % 7 % 2;
+
+	return days;
+}
+
+/*
+ * Ticks a BCD register according to the specified constraints.
+ */
+static uint8_t
+ds1338_virt_tick_bcd_reg(bcd_reg_t * bcd_reg)
+{
+	// Unpack BCD
+	uint8_t x = (*bcd_reg->reg & 0x0F) +
+			10*((*bcd_reg->reg & bcd_reg->tens_mask) >> 4);
+
+	// Tick
+	uint8_t cascade = 0;
+	if (++x > bcd_reg->max_val) {
+		x = bcd_reg->min_val;
+		cascade = 1;
+	}
+
+	// Set the BCD part of the register
+	*bcd_reg->reg &= ~(0x0F | bcd_reg->tens_mask);
+	*bcd_reg->reg |= (x / 10 << 4) + x % 10;
+
+	return cascade;
+}
+
+/*
+ * Ticks the time registers. See table 3, p10 of the DS1338 datasheet.
+ */
+static void
+ds1338_virt_tick_time(ds1338_virt_t *p) {
+
+	/*
+	 * Seconds
+	 */
+	bcd_reg_t reg = {
+		.reg = &p->nvram[DS1338_VIRT_SECONDS],
+		.min_val = 0,
+		.max_val = 59,
+		.tens_mask = 0b01110000
+	};
+	uint8_t cascade = ds1338_virt_tick_bcd_reg(&reg);
+	if (!cascade)
+		return;
+
+	/*
+	 * Minutes
+	 */
+	reg.reg = &p->nvram[DS1338_VIRT_MINUTES];
+	cascade = ds1338_virt_tick_bcd_reg(&reg);
+	if (!cascade)
+		return;
+
+	/*
+	 * Hours
+	 */
+	reg.reg = &p->nvram[DS1338_VIRT_HOURS];
+	if (ds1338_get_flag(p->nvram[DS1338_VIRT_HOURS], DS1338_VIRT_12_24_HR)) {
+		// 12 hour mode
+		reg.min_val = 1;
+		reg.max_val = 12;
+		reg.tens_mask = 0b00010000;
+		uint8_t pm = ds1338_get_flag(p->nvram[DS1338_VIRT_HOURS], DS1338_VIRT_AM_PM);
+		cascade = ds1338_virt_tick_bcd_reg(&reg);
+		if (cascade) {
+			if (pm) {
+				// Switch to AM
+				p->nvram[DS1338_VIRT_HOURS] &= !(1 << DS1338_VIRT_AM_PM);
+			} else {
+				// Switch to PM and catch the cascade
+				p->nvram[DS1338_VIRT_HOURS] |= (1 << DS1338_VIRT_AM_PM);
+				cascade = 0;
+			}
+		}
+	} else {
+		// 24 hour mode
+		reg.min_val = 0;
+		reg.max_val = 23;
+		reg.tens_mask = 0b00110000;
+		cascade = ds1338_virt_tick_bcd_reg(&reg);
+	}
+	if (!cascade)
+		return;
+
+	/*
+	 * Day
+	 */
+	reg.reg = &p->nvram[DS1338_VIRT_DAY];
+	reg.min_val = 1;
+	reg.max_val = 7;
+	reg.tens_mask = 0;
+	ds1338_virt_tick_bcd_reg(&reg);
+
+	/*
+	 * Date
+	 */
+	reg.reg = &p->nvram[DS1338_VIRT_DATE];
+	// Insert a y2.1k bug like they do in the original part
+	uint16_t year = 2000 + UNPACK_BCD(p->nvram[DS1338_VIRT_YEAR]);
+	reg.max_val = ds1338_virt_days_in_month(
+	               UNPACK_BCD(p->nvram[DS1338_VIRT_MONTH]),
+	               year);
+	reg.tens_mask = 0b00110000;
+	cascade = ds1338_virt_tick_bcd_reg(&reg);
+	if (!cascade)
+		return;
+
+	/*
+	 * Month
+	 */
+	reg.reg = &p->nvram[DS1338_VIRT_MONTH];
+	reg.max_val = 12;
+	reg.tens_mask = 0b00010000;
+	cascade = ds1338_virt_tick_bcd_reg(&reg);
+	if (!cascade)
+		return;
+
+	/*
+	 * Year
+	 */
+	reg.reg = &p->nvram[DS1338_VIRT_YEAR];
+	reg.min_val = 0;
+	reg.max_val = 99;
+	reg.tens_mask = 0b11110000;
+	cascade = ds1338_virt_tick_bcd_reg(&reg);
+}
+
+static void
+ds1338_virt_cycle_square_wave(ds1338_virt_t *p)
+{
+	if(!ds1338_get_flag(p->nvram[DS1338_VIRT_CONTROL], DS1338_VIRT_SQWE)) {
+		printf("DS1338: SQWE disabled");
+		// Square wave output disabled
+		return;
+	}
+
+	p->square_wave = !p->square_wave;
+
+	if (p->square_wave) {
+		avr_raise_irq(p->irq + DS1338_SQW_IRQ_OUT, 1);
+		//printf ("Tick\n");
+	} else {
+		avr_raise_irq(p->irq + DS1338_SQW_IRQ_OUT, 0);
+		//printf ("Tock\n");
+	}
+}
+
+/*
+ * This function is left in for debugging.
+ */
+static void
+ds1338_print_time(ds1338_virt_t *p)
+{
+	uint8_t seconds = (p->nvram[DS1338_VIRT_SECONDS] & 0xF)
+	                + ((p->nvram[DS1338_VIRT_SECONDS] & 0b01110000) >> 4) * 10;
+	uint8_t minutes = (p->nvram[DS1338_VIRT_MINUTES] & 0xF)
+	                + (p->nvram[DS1338_VIRT_MINUTES] >> 4) * 10;
+
+	uint8_t pm = 0;
+	uint8_t hours;
+	if (ds1338_get_flag (p->nvram[DS1338_VIRT_HOURS], DS1338_VIRT_12_24_HR))
+	{
+		// 12hr mode
+		pm = ds1338_get_flag(p->nvram[DS1338_VIRT_HOURS],
+		                      DS1338_VIRT_AM_PM);
+		hours = (p->nvram[DS1338_VIRT_HOURS] & 0xF)
+		                + ((p->nvram[DS1338_VIRT_HOURS] & 0b00010000) >> 4) * 10;
+	} else {
+		// 24hr mode
+		hours = (p->nvram[DS1338_VIRT_HOURS] & 0xF)
+		                + ((p->nvram[DS1338_VIRT_HOURS] & 0b00110000) >> 4) * 10;
+	}
+
+	uint8_t day = p->nvram[DS1338_VIRT_DAY] & 0b00000111;
+	uint8_t date = (p->nvram[DS1338_VIRT_DATE] & 0xF)
+	                + (p->nvram[DS1338_VIRT_DATE] >> 4) * 10;
+	uint8_t month = (p->nvram[DS1338_VIRT_MONTH] & 0xF)
+	                + (p->nvram[DS1338_VIRT_MONTH] >> 4) * 10;
+	uint8_t year = (p->nvram[DS1338_VIRT_YEAR] & 0xF)
+	                + (p->nvram[DS1338_VIRT_YEAR] >> 4) * 10;
+
+	if(p->verbose)
+		printf("Time: %02i:%02i:%02i  Day: %i Date: %02i:%02i:%02i PM:%01x\n",
+		        hours, minutes, seconds, day, date, month, year, pm);
+}
+
+static avr_cycle_count_t
+ds1338_virt_clock_tick(struct avr_t * avr,
+                       avr_cycle_count_t when,
+                       ds1338_virt_t *p)
+{
+	avr_cycle_count_t next_tick = when + avr_usec_to_cycles(avr, DS1338_CLK_PERIOD_US / 2);
+
+	if (!ds1338_get_flag(p->nvram[DS1338_VIRT_SECONDS], DS1338_VIRT_CH)) {
+		// Oscillator is enabled. Note that this counter is allowed to wrap.
+		p->rtc++;
+	} else {
+		// Avoid a condition match below with the clock switched off
+		return next_tick;
+	}
+
+	/*
+	 * Update the time
+	 */
+	if (p->rtc == 0) {
+		// 1 second has passed
+		ds1338_virt_tick_time(p);
+                if (p->verbose)
+			ds1338_print_time(p);
+	}
+
+	/*
+	 * Deal with the square wave output
+	 */
+	uint8_t prescaler_mode = ds1338_get_flag(p->nvram[DS1338_VIRT_CONTROL],
+	                                         DS1338_VIRT_RS0)
+	                      + (ds1338_get_flag(p->nvram[DS1338_VIRT_CONTROL],
+	                                         DS1338_VIRT_RS1) << 1);
+
+	switch (prescaler_mode)
+	{
+		case DS1338_VIRT_PRESCALER_DIV_32768:
+			if ((p->rtc + 1) % DS1338_CLK_FREQ == 0) {
+				ds1338_virt_cycle_square_wave(p);
+			}
+			break;
+		case DS1338_VIRT_PRESCALER_DIV_8:
+			if ((p->rtc + 1) % (DS1338_CLK_FREQ / 8) == 0)
+				ds1338_virt_cycle_square_wave(p);
+			break;
+		case DS1338_VIRT_PRESCALER_DIV_4:
+			if ((p->rtc + 1) % (DS1338_CLK_FREQ / 4) == 0)
+				ds1338_virt_cycle_square_wave(p);
+			break;
+		case DS1338_VIRT_PRESCALER_OFF:
+			ds1338_virt_cycle_square_wave(p);
+			break;
+		default:
+			printf("DS1338 ERROR: PRESCALER MODE INVALID\n");
+			break;
+	}
+
+	return next_tick;
+}
+
+static void
+ds1338_virt_clock_xtal_init(struct avr_t * avr,
+                            ds1338_virt_t *p)
+{
+	p->rtc = 0;
+
+	/*
+	 * Set a timer for half the clock period to allow reconstruction
+	 * of the square wave output at the maximum possible frequency.
+	 */
+	avr_cycle_timer_register_usec(avr,
+	                              DS1338_CLK_PERIOD_US / 2,
+	                              (void *) ds1338_virt_clock_tick,
+	                              p);
+
+	printf("DS1338 clock crystal period %duS or %d cycles\n",
+			DS1338_CLK_PERIOD_US,
+			(int)avr_usec_to_cycles(avr, DS1338_CLK_PERIOD_US));
+}
+
+/*
+ * Called when a RESET signal is sent
+ */
+static void
+ds1338_virt_in_hook(struct avr_irq_t * irq,
+                    uint32_t value,
+                    void * param)
+{
+	ds1338_virt_t * p = (ds1338_virt_t*)param;
+	avr_twi_msg_irq_t v;
+	v.u.v = value;
+
+	/*
+	 * If we receive a STOP, check it was meant to us, and reset the transaction
+	 */
+	if (v.u.twi.msg & TWI_COND_STOP) {
+		if (p->selected) {
+			// Wahoo, it was us!
+			if (p->verbose)
+				printf("DS1338 stop\n\n");
+		}
+		/* We should not zero the register address here because read mode uses the last
+		 * register address stored and write mode always overwrites it.
+		 */
+		p->selected = 0;
+		p->reg_selected = 0;
+	}
+
+	/*
+	 * If we receive a start, reset status, check if the slave address is
+	 * meant to be us, and if so reply with an ACK bit
+	 */
+	if (v.u.twi.msg & TWI_COND_START) {
+		//printf("DS1338 start attempt: 0x%02x, mask: 0x%02x,
+		//twi: 0x%02x\n", p->addr_base, p->addr_mask, v.u.twi.addr);
+		p->selected = 0;
+		// Ignore the read write bit
+		if ((v.u.twi.addr >> 1) ==  (DS1338_VIRT_TWI_ADDR >> 1)) {
+			// it's us !
+			if (p->verbose)
+				printf("DS1338 start\n");
+			p->selected = v.u.twi.addr;
+			avr_raise_irq(p->irq + TWI_IRQ_INPUT,
+					avr_twi_irq_msg(TWI_COND_ACK, p->selected, 1));
+		}
+	}
+
+	/*
+	 * If it's a data transaction, first check it is meant to be us (we
+	 * received the correct address and are selected)
+	 */
+	if (p->selected) {
+		// Write transaction
+		if (v.u.twi.msg & TWI_COND_WRITE) {
+			// ACK the byte
+			avr_raise_irq(p->irq + TWI_IRQ_INPUT,
+					avr_twi_irq_msg(TWI_COND_ACK, p->selected, 1));
+			// Write to the selected register (see p13. DS1388 datasheet for details)
+			if (p->reg_selected) {
+				if (p->verbose)
+					printf("DS1338 set register 0x%02x to 0x%02x\n", 
+						p->reg_addr, v.u.twi.data);
+				p->nvram[p->reg_addr] = v.u.twi.data;
+				ds1338_virt_update(p);
+				ds1338_virt_incr_addr(p);
+			// No register selected so select one
+			} else {
+				if (p->verbose)
+					printf("DS1338 select register 0x%02x\n",  v.u.twi.data);
+				p->reg_selected = 1;
+				p->reg_addr = v.u.twi.data;
+			}
+		}
+		// Read transaction
+		if (v.u.twi.msg & TWI_COND_READ) {
+			if (p->verbose)
+				printf("DS1338 READ data at 0x%02x: 0x%02x\n",
+					p->reg_addr, p->nvram[p->reg_addr]);
+			uint8_t data = p->nvram[p->reg_addr];
+			ds1338_virt_incr_addr(p);
+			avr_raise_irq(p->irq + TWI_IRQ_INPUT,
+					avr_twi_irq_msg(TWI_COND_READ, p->selected, data));
+		}
+	}
+}
+
+static const char * _ds1338_irq_names[DS1338_IRQ_COUNT] = {
+	[DS1338_TWI_IRQ_INPUT] = "8>ds1338.out",
+	[DS1338_TWI_IRQ_OUTPUT] = "32<ds1338.in",
+	[DS1338_SQW_IRQ_OUT] = ">ds1338_sqw.out",
+};
+
+/*
+ * Initialise the DS1388 virtual part. This should be called before anything else.
+ */
+void
+ds1338_virt_init(struct avr_t * avr,
+                 ds1338_virt_t * p)
+{
+	memset(p, 0, sizeof(*p));
+	memset(p->nvram, 0x00, sizeof(p->nvram));
+	// Default for day counter. Strangely it runs from 1-7.
+	p->nvram[DS1338_VIRT_DAY] = 1;
+
+	p->avr = avr;
+
+	p->irq = avr_alloc_irq(&avr->irq_pool, 0, DS1338_IRQ_COUNT, _ds1338_irq_names);
+	avr_irq_register_notify(p->irq + TWI_IRQ_OUTPUT, ds1338_virt_in_hook, p);
+
+	// Start with the oscillator disabled, at least until there is some "battery backup"
+	p->nvram[DS1338_VIRT_SECONDS] |=  (1 << DS1338_VIRT_CH);
+
+	ds1338_virt_clock_xtal_init(avr, p);
+}
+
+/*
+ *  "Connect" the IRQs of the DS1338 to the TWI/i2c master of the AVR.
+ */
+void
+ds1338_virt_attach_twi(ds1338_virt_t * p,
+                       uint32_t i2c_irq_base)
+{
+	avr_connect_irq(
+		p->irq + TWI_IRQ_INPUT,
+		avr_io_getirq(p->avr, i2c_irq_base, TWI_IRQ_INPUT));
+	avr_connect_irq(
+		avr_io_getirq(p->avr, i2c_irq_base, TWI_IRQ_OUTPUT),
+		p->irq + TWI_IRQ_OUTPUT);
+}
+
+/*
+ * Optionally "connect" the square wave out IRQ to the AVR.
+ */
+void
+ds1338_virt_attach_square_wave_output(ds1338_virt_t * p,
+                                      ds1338_pin_t * wiring)
+{
+	avr_connect_irq(
+		p->irq + DS1338_SQW_IRQ_OUT,
+	        avr_io_getirq(p->avr, AVR_IOCTL_IOPORT_GETIRQ(wiring->port), wiring->pin));
+}
+

--- a/examples/parts/ds1338_virt.h
+++ b/examples/parts/ds1338_virt.h
@@ -1,0 +1,185 @@
+/*
+	ds1338_virt.h
+
+	Copyright 2014 Doug Szumski <d.s.szumski@gmail.com>
+
+	Based on i2c_eeprom example by:
+
+	Copyright 2008, 2009 Michel Pollet <buserror@gmail.com>
+
+ 	This file is part of simavr.
+
+	simavr is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	simavr is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with simavr.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ *  A virtual DS1338 real time clock which runs on the TWI bus.
+ *
+ *  Features:
+ *
+ *  > External oscillator is synced to the AVR core
+ *  > Square wave output with scalable frequency
+ *  > Leap year correction until 2100
+ *
+ *  Should also work for the pin compatible DS1307 device.
+ */
+
+#ifndef DS1338_VIRT_H_
+#define DS1338_VIRT_H_
+
+#include "sim_irq.h"
+#include "sim_avr.h"
+#include "avr_ioport.h"
+
+// TWI address is fixed
+#define DS1338_VIRT_TWI_ADDR		0xD0
+
+/*
+ * Internal registers. Time is in BCD.
+ * See p10 of the DS1388 datasheet.
+ */
+#define DS1338_VIRT_SECONDS		0x00
+#define DS1338_VIRT_MINUTES		0x01
+#define DS1338_VIRT_HOURS		0x02
+#define DS1338_VIRT_DAY			0x03
+#define DS1338_VIRT_DATE		0x04
+#define DS1338_VIRT_MONTH		0x05
+#define DS1338_VIRT_YEAR		0x06
+#define DS1338_VIRT_CONTROL		0x07
+
+/*
+ * Seconds register flag - oscillator is enabled when
+ * this is set to zero. Undefined on startup.
+ */
+#define DS1338_VIRT_CH			7
+
+/*
+ * 12/24 hour select bit. When high clock is in 12 hour
+ * mode and the AM/PM bit is operational. When low the
+ * AM/PM bit becomes part of the tens counter for the
+ * 24 hour clock.
+ */
+#define DS1338_VIRT_12_24_HR		6
+
+/*
+ * AM/PM flag for 12 hour mode. PM is high.
+ */
+#define DS1338_VIRT_AM_PM		5
+
+/*
+ * Control register flags. See p11 of the DS1388 datasheet.
+ *
+ *  +-----+-----+-----+------------+------+
+ *  | OUT | RS1 | RS0 | SQW_OUTPUT | SQWE |
+ *  +-----+-----+-----+------------+------+
+ *  | X   | 0   | 0   | 1Hz        |    1 |
+ *  | X   | 0   | 1   | 4.096kHz   |    1 |
+ *  | X   | 1   | 0   | 8.192kHz   |    1 |
+ *  | X   | 1   | 1   | 32.768kHz  |    1 |
+ *  | 0   | X   | X   | 0          |    0 |
+ *  | 1   | X   | X   | 1          |    0 |
+ *  +-----+-----+-----+------------+------+
+ *
+ *  OSF : Oscillator stop flag. Set to 1 when oscillator
+ *        is interrupted.
+ *
+ *  SQWE : Square wave out, set to 1 to enable.
+ */
+#define DS1338_VIRT_RS0			0
+#define DS1338_VIRT_RS1			1
+#define DS1338_VIRT_SQWE		4
+#define DS1338_VIRT_OSF			5
+#define DS1338_VIRT_OUT			7
+
+#define DS1338_CLK_FREQ 32768
+#define DS1338_CLK_PERIOD_US (1000000 / DS1338_CLK_FREQ)
+
+// Generic unpack of 8bit BCD register. Don't use on seconds or hours.
+#define UNPACK_BCD(x) (((x) & 0x0F) + ((x) >> 4) * 10)
+
+enum {
+	DS1338_TWI_IRQ_OUTPUT = 0,
+	DS1338_TWI_IRQ_INPUT,
+	DS1338_SQW_IRQ_OUT,
+	DS1338_IRQ_COUNT
+};
+
+/*
+ * Square wave out prescaler modes; see p11 of DS1338 datasheet.
+ */
+enum {
+	DS1338_VIRT_PRESCALER_DIV_32768 = 0,
+	DS1338_VIRT_PRESCALER_DIV_8,
+	DS1338_VIRT_PRESCALER_DIV_4,
+	DS1338_VIRT_PRESCALER_OFF,
+};
+
+/*
+ * Describes the behaviour of the specified BCD register.
+ *
+ * The tens mask is used to avoid config bits present in
+ * the same register.
+ */
+typedef struct bcd_reg_t {
+	uint8_t * reg;
+	uint8_t min_val;
+	uint8_t max_val;
+	uint8_t tens_mask;
+} bcd_reg_t;
+
+// TODO: This should be generic, is also used in ssd1306, and maybe elsewhere..
+typedef struct ds1338_pin_t
+{
+	char port;
+	uint8_t pin;
+} ds1338_pin_t;
+
+/*
+ * DS1338 I2C clock
+ */
+typedef struct ds1338_virt_t {
+	struct avr_t * avr;
+	avr_irq_t * irq;		// irq list
+	uint8_t verbose;
+	uint8_t selected;		// selected address
+	uint8_t reg_selected;		// register selected for write
+	uint8_t reg_addr;		// register pointer
+	uint8_t nvram[64];		// battery backed up NVRAM
+	uint16_t rtc;			// RTC counter
+	uint8_t square_wave;
+} ds1338_virt_t;
+
+void
+ds1338_virt_init(struct avr_t * avr,
+                 ds1338_virt_t * p);
+
+/*
+ * Attach the ds1307 to the AVR's TWI master code,
+ * pass AVR_IOCTL_TWI_GETIRQ(0) for example as i2c_irq_base
+ */
+void
+ds1338_virt_attach_twi(ds1338_virt_t * p,
+                       uint32_t i2c_irq_base);
+
+void
+ds1338_virt_attach_square_wave_output(ds1338_virt_t * p,
+                                      ds1338_pin_t * wiring);
+
+static inline int
+ds1338_get_flag(uint8_t reg, uint8_t bit)
+{
+	return (reg & (1 << bit)) != 0;
+}
+
+#endif /* DS1338_VIRT_H_ */


### PR DESCRIPTION
A virtual DS1338 real time clock which runs on the TWI bus.

Features:

> External oscillator synced to the AVR core
> Square wave output with scalable frequency
> Leap year correction until 2100 (just like the real thing!)

Should also work for the pin compatible DS1307 device, but that part
hasn't been tested against actual hardware.

Includes a demo.