### PR TITLE
Compilation on Mac OS X without homebrew or MacPorts

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -26,6 +26,8 @@
 #	You should have received a copy of the GNU General Public License
 #	along with simavr.  If not, see <http://www.gnu.org/licenses/>.
 
+V=1
+
 # simavr directory
 SIMAVR		:= ${shell for p in . .. ../.. ../../..;do test -d $$p/simavr/sim && echo $$p/simavr; done}
 
@@ -46,9 +48,12 @@ CORE_CFLAGS	= -nostdinc -DAVR_CORE=1
 ifeq (${shell uname}, Darwin)
  # gcc 4.2 from MacOS is really not up to scratch anymore 
  CC			= clang
- AVR_ROOT 	:= "/Applications/Arduino.app/Contents/Resources/Java/hardware/tools/avr/"
- AVR_INC 	:= ${AVR_ROOT}/avr/
+ AVR_ROOT 	:= /Applications/Arduino.app/Contents/Java/hardware/tools/avr
+ AVR_INC 	:= ${AVR_ROOT}/avr
  AVR 		:= ${AVR_ROOT}/bin/avr-
+ IPATH		+= /usr/local/include
+ LFLAGS		= -L/usr/local/lib/
+
  # Thats for MacPorts libelf
  ifeq (${shell test -d /opt/local && echo Exists}, Exists)
   IPATH		+= /opt/local/include
@@ -157,34 +162,13 @@ endif
 
 # this rule has precedence
 ${OBJ}/sim_%.o : cores/sim_%.c
-ifeq ($(V),1)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(CORE_CFLAGS) -MMD \
-		${AVR_CPPFLAGS} \
-		$<  -c -o $@
-else
-	@$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS) $(CORE_CFLAGS) -MMD \
-		${AVR_CPPFLAGS} \
-		$<  -c -o $@
-	@echo CORE $<
-endif
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(CORE_CFLAGS) -MMD ${AVR_CPPFLAGS} $< -c -o $@
 
 ${OBJ}/%.o: %.c
-ifeq ($(V),1)
-	$(CC) $(CPPFLAGS) $(CFLAGS) -MMD \
-		$<  -c -o $@
-else
-	@$(CC) $(CPPFLAGS) $(CFLAGS) -MMD \
-		$<  -c -o $@
-	@echo CC $<
-endif
+	$(CC) $(CPPFLAGS) $(CFLAGS) -MMD $<  -c -o $@
 
 ${OBJ}/%.elf:
-ifeq ($(V),1)
 	$(CC) -MMD ${CFLAGS}  ${LFLAGS} -o $@ $^ $(LDFLAGS)
-else
-	@echo LD $@
-	@$(CC) -MMD ${CFLAGS}  ${LFLAGS} -o $@ $^ $(LDFLAGS)
-endif
 
 obj: ${OBJ}
  

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,7 +1,7 @@
-
 boards_base=${wildcard board_*}
+
 # Remove simduino until FileMapping is implemented to work around missing mmap in Win32
-ifeq (${shell uname -o}, Msys)
+ifeq (${shell uname}, Msys)
 boards=${subst board_usb,,${subst board_simduino,,$(boards_base)}}
 else
 boards=$(boards_base)

--- a/simavr/Makefile
+++ b/simavr/Makefile
@@ -160,8 +160,8 @@ sim_core_config.h ${OBJ}/cores.deps: $(cores) Makefile
 	for core in cores/*.c ; do \
 		file=$$core; global=$${core/cores\/sim_}; global=$${global/.c}; \
 		upper=$$(echo $$global|tr '[a-z]' '[A-Z]'); \
-		if $(CC) -E $(CFLAGS) ${AVR_CPPFLAGS} $$file \
-			>>$(DEBUGLOG) 2>&1 ; then \
+		echo $(CC) -E $(CFLAGS) ${AVR_CPPFLAGS} $$file; \
+		if $(CC) -E $(CFLAGS) ${AVR_CPPFLAGS} $$file >>$(DEBUGLOG) 2>&1 ; then \
 			conf+="#define CONFIG_$$upper 1\n"; \
 			obj=$${file/.c/.o} ; obj=$${obj/cores\/}; \
 			printf "\$${OBJ}/libsimavr.a: \$${OBJ}/$$obj\n">>${OBJ}/cores.deps ; \


### PR DESCRIPTION
There may be more changes in this than you want to merge into your own branch.  I had to undo some of the hiding of command that the makefile was doing in order to see why things weren't compiling for me.  The crux of the fix is this change in Makefile.common:

```
- AVR_ROOT 	:= "/Applications/Arduino.app/Contents/Resources/Java/hardware/tools/avr/"
- AVR_INC 	:= ${AVR_ROOT}/avr/
+ AVR_ROOT 	:= /Applications/Arduino.app/Contents/Java/hardware/tools/avr
+ AVR_INC 	:= ${AVR_ROOT}/avr

+ IPATH		+= /usr/local/include
+ LFLAGS    = -L/usr/local/lib/
```

The path to the avr directory in the latest Arduino.app no longer includes the `Resources` directory.   The trailing slashes and quotes are not needed because the uses of the `AVR_ROOT` and `AVR_INC` add slashes.  I needed additional include paths for libelf because I compiled it the old-fashioned way using `./configure; make; make install` and it went into `/usr/local/lib` and `/usr/local/include`.