### PR TITLE
Improve usage message by not listing cores by default

### DIFF
--- a/simavr/sim/run_avr.c
+++ b/simavr/sim/run_avr.c
@@ -40,6 +40,12 @@ void display_usage(char * app)
 		   "       -ff: Load next .hex file as flash\n"
 		   "       -ee: Load next .hex file as eeprom\n"
 		   "       -v: Raise verbosity level (can be passed more than once)\n"
+		   "       --list-cores: List all supported AVR cores\n");
+	exit(1);
+}
+
+void list_cores() {
+	printf(
 		   "   Supported AVR cores:\n");
 	for (int i = 0; avr_kind[i]; i++) {
 		printf("       ");
@@ -78,7 +84,9 @@ int main(int argc, char *argv[])
 		display_usage(basename(argv[0]));
 
 	for (int pi = 1; pi < argc; pi++) {
-		if (!strcmp(argv[pi], "-h") || !strcmp(argv[pi], "-help")) {
+		if (!strcmp(argv[pi], "--list-cores")) {
+			list_cores();
+		} else if (!strcmp(argv[pi], "-h") || !strcmp(argv[pi], "-help")) {
 			display_usage(basename(argv[0]));
 		} else if (!strcmp(argv[pi], "-m") || !strcmp(argv[pi], "-mcu")) {
 			if (pi < argc-1)

--- a/simavr/sim/run_avr.c
+++ b/simavr/sim/run_avr.c
@@ -34,14 +34,15 @@
 
 void display_usage(char * app)
 {
-	printf("Usage: %s [-list-cores] [-help] [-t] [-g] [-v] [-m <device>] [-f <frequency>] firmware\n", app);
-	printf(    "       -list-cores: List all supported AVR cores and exit\n"
-		   "       -help: Display this usage message and exit\n"
-		   "       -t: Run full scale decoder trace\n"
-		   "       -g: Listen for gdb connection on port 1234\n"
-		   "       -ff: Load next .hex file as flash\n"
-		   "       -ee: Load next .hex file as eeprom\n"
-		   "       -v: Raise verbosity level (can be passed more than once)\n");
+	printf("Usage: %s [--list-cores] [--help] [-t] [-g] [-v] [-m <device>] [-f <frequency>] firmware\n", app);
+        printf(    "       --list-cores      List all supported AVR cores and exit\n"
+		   "       --help, -h        Display this usage message and exit\n"
+		   "       -trace, -t        Run full scale decoder trace\n"
+                   "       -ti <vector>      Add trace vector at <vector>\n"
+		   "       -gdb, -g          Listen for gdb connection on port 1234\n"
+		   "       -ff               Load next .hex file as flash\n"
+		   "       -ee               Load next .hex file as eeprom\n"
+		   "       -v                Raise verbosity level (can be passed more than once)\n");
 	exit(1);
 }
 
@@ -85,9 +86,9 @@ int main(int argc, char *argv[])
 		display_usage(basename(argv[0]));
 
 	for (int pi = 1; pi < argc; pi++) {
-		if (!strcmp(argv[pi], "-list-cores")) {
+		if (!strcmp(argv[pi], "--list-cores")) {
 			list_cores();
-		} else if (!strcmp(argv[pi], "-h") || !strcmp(argv[pi], "-help")) {
+		} else if (!strcmp(argv[pi], "-h") || !strcmp(argv[pi], "--help")) {
 			display_usage(basename(argv[0]));
 		} else if (!strcmp(argv[pi], "-m") || !strcmp(argv[pi], "-mcu")) {
 			if (pi < argc-1)

--- a/simavr/sim/run_avr.c
+++ b/simavr/sim/run_avr.c
@@ -34,13 +34,14 @@
 
 void display_usage(char * app)
 {
-	printf("Usage: %s [-t] [-g] [-v] [-m <device>] [-f <frequency>] firmware\n", app);
-	printf("       -t: Run full scale decoder trace\n"
+	printf("Usage: %s [-list-cores] [-help] [-t] [-g] [-v] [-m <device>] [-f <frequency>] firmware\n", app);
+	printf(    "       -list-cores: List all supported AVR cores and exit\n"
+		   "       -help: Display this usage message and exit\n"
+		   "       -t: Run full scale decoder trace\n"
 		   "       -g: Listen for gdb connection on port 1234\n"
 		   "       -ff: Load next .hex file as flash\n"
 		   "       -ee: Load next .hex file as eeprom\n"
-		   "       -v: Raise verbosity level (can be passed more than once)\n"
-		   "       --list-cores: List all supported AVR cores\n");
+		   "       -v: Raise verbosity level (can be passed more than once)\n");
 	exit(1);
 }
 
@@ -84,7 +85,7 @@ int main(int argc, char *argv[])
 		display_usage(basename(argv[0]));
 
 	for (int pi = 1; pi < argc; pi++) {
-		if (!strcmp(argv[pi], "--list-cores")) {
+		if (!strcmp(argv[pi], "-list-cores")) {
 			list_cores();
 		} else if (!strcmp(argv[pi], "-h") || !strcmp(argv[pi], "-help")) {
 			display_usage(basename(argv[0]));


### PR DESCRIPTION
Listing all the cores by default pushes the basic usage message off the screen for most reasonably-sized terminals.  I have added the "--list-cores" option:

```
$ simavr 
Usage: run_avr [-list-cores] [-help] [-t] [-g] [-v] [-m <device>] [-f <frequency>] firmware
       -list-cores: List all supported AVR cores and exit
       -help: Display this usage message and exit
       -t: Run full scale decoder trace
       -g: Listen for gdb connection on port 1234
       -ff: Load next .hex file as flash
       -ee: Load next .hex file as eeprom
       -v: Raise verbosity level (can be passed more than once)

$ simavr -list-cores
[... long list of supported cores ...]
```
