### PR TITLE
avr_timer.c: Initialize `tov_cycles_exact`

### DIFF
--- a/simavr/sim/avr_timer.c
+++ b/simavr/sim/avr_timer.c
@@ -437,7 +437,7 @@ avr_timer_configure(
 
 	avr_t * avr = p->io.avr;
 	float resulting_clock = 0.0f; // used only for trace
-	float tov_cycles_exact;
+	float tov_cycles_exact = 0.0f;
 
 	uint8_t as2 = p->ext_clock_flags & AVR_TIMER_EXTCLK_FLAG_AS2;
 	uint8_t use_ext_clock = as2 || (p->ext_clock_flags & AVR_TIMER_EXTCLK_FLAG_TN);


### PR DESCRIPTION
`tov_cycles_exact` may be used uninitialized in `AVR_LOG()` (avr_timer.c:468) since the `if` case in line 453 doesn't assign a value to it, issuing a warning.  Since the code seems to be compiled with `-Werror`, it fails to compile:
```
CC sim/avr_spi.c
cc1: warnings being treated as errors
sim/avr_timer.c: In function ‘avr_timer_configure’:
sim/avr_timer.c:440: error: ‘tov_cycles_exact’ may be used uninitialized in this function
make[2]: *** [obj-x86_64-linux-gnu/avr_timer.o] Error 1
```

This commit initializes `tov_cycles_exact` to 0.0f to avoid the warning.