### PR TITLE
adc control register write

### DIFF
--- a/simavr/sim/avr_adc.c
+++ b/simavr/sim/avr_adc.c
@@ -206,7 +206,6 @@ static void
 avr_adc_write_adcsra(
 		struct avr_t * avr, avr_io_addr_t addr, uint8_t v, void * param)
 {
-	avr_adc_configure_trigger(avr, addr, v, param);
 	
 	avr_adc_t * p = (avr_adc_t *)param;
 	uint8_t adsc = avr_regbit_get(avr, p->adsc);
@@ -253,12 +252,14 @@ avr_adc_write_adcsra(
 				avr_adc_int_raise, p);
 	}
 	avr_core_watch_write(avr, addr, v);
+	avr_adc_configure_trigger(avr, addr, v, param);
 }
 
 static void
 avr_adc_write_adcsrb(
 		struct avr_t * avr, avr_io_addr_t addr, uint8_t v, void * param)
 {
+	avr_core_watch_write(avr, addr, v);
 	avr_adc_configure_trigger(avr, addr, v, param);
 }
 


### PR DESCRIPTION
ensure that the adsrb is written to memory
process avr_adc_configure_trigger after writing the value to memory


I ran into this when trying to run a modem package that relied on timer trigger in the adc.  This should clean it up a bit to generate logs indicating which modes are supported and not supported. 
