### PR TITLE
Set prescaler divisor (cs_div_value) to zero when prescaler is reset,…

### DIFF
--- a/simavr/sim/avr_timer.c
+++ b/simavr/sim/avr_timer.c
@@ -662,6 +662,7 @@ avr_timer_write(
 	if (new_cs != cs || new_mode != mode || new_as2 != as2) {
 	/* cs */
 		if (new_cs == 0) {
+			p->cs_div_value = 0;		// reset prescaler
 			// cancel everything
 			avr_timer_cancel_all_cycle_timers(avr, p, 1);
 


### PR DESCRIPTION
… i.e. timer is stopped. Otherwise when OCR is set, the timer gets reconfigured with the old prescaler and starts running when it's not supposed to.
