### PR TITLE
avoid strdupa, which is unsupported on osx with clang.

### DIFF
--- a/simavr/sim/sim_vcd_file.c
+++ b/simavr/sim/sim_vcd_file.c
@@ -21,7 +21,6 @@
 	You should have received a copy of the GNU General Public License
 	along with simavr.  If not, see <http://www.gnu.org/licenses/>.
  */
-#define _GNU_SOURCE /* for strdupa */
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -295,7 +294,7 @@ avr_vcd_init_input(
 				vcd->signal[i].size);
 		/* format is <four-character ioctl>[_<IRQ index>] */
 		if (strlen(vcd->signal[i].name) >= 4) {
-			char *dup = strdupa(vcd->signal[i].name);
+			char *dup = strdup(vcd->signal[i].name);
 			char *ioctl = strsep(&dup, "_");
 			int index = 0;
 			if (dup)
@@ -311,11 +310,12 @@ avr_vcd_init_input(
 					AVR_LOG(vcd->avr, LOG_WARNING,
 							"%s IRQ was not found\n",
 							vcd->signal[i].name);
-				continue;
+			} else {
+				AVR_LOG(vcd->avr, LOG_WARNING,
+						"%s is an invalid IRQ format\n",
+						vcd->signal[i].name);
 			}
-			AVR_LOG(vcd->avr, LOG_WARNING,
-					"%s is an invalid IRQ format\n",
-					vcd->signal[i].name);
+			if(dup) free(dup);
 		}
 	}
 	return 0;

--- a/simavr/sim/sim_vcd_file.c
+++ b/simavr/sim/sim_vcd_file.c
@@ -296,16 +296,15 @@ avr_vcd_init_input(
 		size_t namelen = strlen(vcd->signal[i].name);
 
 		if (namelen >= 4 && namelen < 20) {
-			char copy[20];
-			char *dup = copy;
-			char *ioctl;
+			char ioctl[20];
+			char *index_string = ioctl;
 			int index = 0;
 
 			strcpy(copy, vcd->signal[i].name);
-			ioctl = strsep(&dup, "_");
-			if (dup)
-				index = atoi(dup);
-			if (ioctl && strlen(ioctl) == 4) {
+			strsep(&index_string, "_");
+			if (index_string)
+				index = atoi(index_string);
+			if (strlen(ioctl) == 4) {
 				uint32_t ioc = AVR_IOCTL_DEF(
 									ioctl[0], ioctl[1], ioctl[2], ioctl[3]);
 				avr_irq_t * irq = avr_io_getirq(vcd->avr, ioc, index);

--- a/simavr/sim/sim_vcd_file.c
+++ b/simavr/sim/sim_vcd_file.c
@@ -296,11 +296,12 @@ avr_vcd_init_input(
 		size_t namelen = strlen(vcd->signal[i].name);
 
 		if (namelen >= 4 && namelen < 20) {
-			char dup[20];
+			char copy[20];
+			char *dup = copy;
 			char *ioctl;
 			int index = 0;
 
-			strcpy(dup, vcd->signal[i].name);
+			strcpy(copy, vcd->signal[i].name);
 			ioctl = strsep(&dup, "_");
 			if (dup)
 				index = atoi(dup);

--- a/simavr/sim/sim_vcd_file.c
+++ b/simavr/sim/sim_vcd_file.c
@@ -300,7 +300,7 @@ avr_vcd_init_input(
 			char *index_string = ioctl;
 			int index = 0;
 
-			strcpy(copy, vcd->signal[i].name);
+			strcpy(ioctl, vcd->signal[i].name);
 			strsep(&index_string, "_");
 			if (index_string)
 				index = atoi(index_string);


### PR DESCRIPTION
I couldn't build on mac with the strdupa calls in sim_vcd_file.c.  Here's a pull request to replace strdupa with strdup/free, as appears common.  I've seen an alternate approach that calls alloca, but since this is in a function that initializes, any extra performance doesn't seem worth the trouble.

```
% make V=1 CC=gcc
/Applications/Xcode.app/Contents/Developer/usr/bin/make -C simavr RELEASE=0
/Applications/Xcode.app/Contents/Developer/usr/bin/make obj config
make[2]: Nothing to be done for `obj'.
make[2]: Nothing to be done for `config'.
/Applications/Xcode.app/Contents/Developer/usr/bin/make libsimavr run_avr
gcc --std=gnu99 -Wall -I/usr/local/include -Isim -I. -I../../shared -Werror -O2 -Wall -g -I//usr/local/include/libelf -fPIC -MMD \
		sim/sim_vcd_file.c  -c -o obj-x86_64-apple-darwin16.1.0/sim_vcd_file.o
sim/sim_vcd_file.c:298:16: error: implicit declaration of function 'strdupa' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
                        char *dup = strdupa(vcd->signal[i].name);
                                    ^
sim/sim_vcd_file.c:298:16: note: did you mean 'strdup'?
/usr/include/string.h:117:7: note: 'strdup' declared here
char    *strdup(const char *__s1);
         ^
sim/sim_vcd_file.c:298:10: error: incompatible integer to pointer conversion initializing 'char *' with an expression of type 'int' [-Werror,-Wint-conversion]
                        char *dup = strdupa(vcd->signal[i].name);
                              ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2 errors generated.
make[2]: *** [obj-x86_64-apple-darwin16.1.0/sim_vcd_file.o] Error 1
make[1]: *** [all] Error 2
make: *** [build-simavr] Error 2
Finest-Worksong:~/cs/cmsc216h/circuit-playground/simavr% gcc --version
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Apple LLVM version 8.0.0 (clang-800.0.42.1)
Target: x86_64-apple-darwin16.1.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

It seems that the typical solution is to replace with strdup/free, e.g., [here](https://lists.fedoraproject.org/pipermail/mutt-kz/2012-March/000015.html) and [here](https://gist.github.com/FlorianFranzen/6353466).  Another project defines it as a macro that combines strcpy, strlen, and alloca() [here](https://ecsft.cern.ch/dist/cvmfs/doc/latest/df/dd4/platform__osx_8h.html).

I've tested briefly, but am still figuring out the codebase.