### PR TITLE
Tinyx4 core, avcc->aref

### DIFF
--- a/simavr/cores/sim_tinyx4.h
+++ b/simavr/cores/sim_tinyx4.h
@@ -94,7 +94,7 @@ const struct mcu_t SIM_CORENAME = {
                     AVR_IO_REGBIT(ADMUX, MUX2), AVR_IO_REGBIT(ADMUX, MUX3),},
         .ref = { AVR_IO_REGBIT(ADMUX, REFS0), AVR_IO_REGBIT(ADMUX, REFS1), },
         .ref_values = {
-                [0] = ADC_VREF_VCC, [1] = ADC_VREF_AVCC,
+                [0] = ADC_VREF_VCC, [1] = ADC_VREF_AREF,
                 [2] = ADC_VREF_V110,
         },
 


### PR DESCRIPTION
Per ATtiny24A datasheet the `REFS1=0, REFS0=1`  indicates **AREF** pin. Unlike on most mega cores where it is `AVCC`.

Table 16-3:  Voltage Reference Selections for ADC:
```
REFS1  REFS0 Voltage Reference Selection
0 0  VCC used as analog reference, disconnected from PA0 (AREF)
0 1  External voltage reference at PA0 (AREF) pin, internal reference turned off
1 0  Internal 1.1V voltage reference
1 1   Reserved
```
