### PR TITLE
Feature/msys2 fix

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -82,6 +82,16 @@ ifeq (${shell uname}, Darwin)
   endif
  endif
 else
+ifeq (${shell uname -o}, Msys)
+ WIN         := Msys
+ AVR_ROOT    := ${shell echo "${AVR32_HOME}" | tr '\\' '/'}
+ AVR_INC     := ${AVR_ROOT}/avr
+ AVR         := ${AVR_ROOT}/bin/avr-
+ IPATH       += ${PREFIX}/include
+ CFLAGS      += -I${PREFIX}/include
+ LDFLAGS     += -L/lib -L/local/lib
+ CFLAGS      += -DNO_COLOR
+else
  LINUX_AVR_ROOTS := /usr/lib/avr /usr/avr /opt/cross/avr/avr /usr/local/avr
  AVR_ROOT := $(firstword $(wildcard $(LINUX_AVR_ROOTS)))
  ifeq (${AVR_ROOT},)
@@ -90,20 +100,6 @@ else
  AVR_INC 	:= ${AVR_ROOT}
  AVR 		:= avr-
 endif
-
-# FIXME uname -o doesn't work on bsd derivatives
-#WIN := ${shell uname -o}
-
-ifeq (${WIN}, Msys)
-AVR_ROOT    := ${shell echo "${AVR32_HOME}" | tr '\\' '/'}
-AVR_INC     := ${AVR_ROOT}/avr
-AVR         := ${AVR_ROOT}/bin/avr-
-IPATH       += ${PREFIX}/include
-CFLAGS      += -I${PREFIX}/include
-LDFLAGS		+= -L/lib -L/local/lib
-CFLAGS 		+= -DNO_COLOR
-else
-CFLAGS 		+= -fPIC
 endif
 
 CPPFLAGS	+= --std=gnu99 -Wall

--- a/Makefile.common
+++ b/Makefile.common
@@ -122,6 +122,8 @@ LDFLAGS 	+= -lelf
 
 ifeq (${WIN}, Msys)
 LDFLAGS      += -lws2_32
+else
+CFLAGS       += -fPIC
 endif
 
 ifeq (${shell uname}, Linux)

--- a/simavr/Makefile
+++ b/simavr/Makefile
@@ -34,7 +34,15 @@ all:
 	$(MAKE) obj config
 	$(MAKE) libsimavr ${target}
 
+# Include common parameters
 include ../Makefile.common
+
+# The name of the target binary after instalation
+ifeq (${WIN}, Msys)
+target_bin = simavr.exe
+else
+target_bin = simavr
+endif
 
 cores	:= ${wildcard cores/*.c}
 sim		:= ${wildcard sim/sim_*.c} ${wildcard sim/avr_*.c}
@@ -113,7 +121,7 @@ ifeq (${shell uname}, Linux)
 	ln -sf libsimavr.so.1 $(DESTDIR)/lib/libsimavr.so
 endif
 	$(MKDIR) $(DESTDIR)/bin
-	$(INSTALL) ${OBJ}/${target}.elf $(DESTDIR)/bin/simavr
+	$(INSTALL) ${OBJ}/${target}.elf $(DESTDIR)/bin/$(target_bin)
 
 # Needs 'fpm', oneline package manager. Install with 'gem install fpm'
 # This generates 'mock' debian files, without all the policy, scripts

--- a/simavr/sim/avr_usb.c
+++ b/simavr/sim/avr_usb.c
@@ -483,7 +483,7 @@ avr_usb_ep_read(
 {
 	avr_usb_t * p = (avr_usb_t *) param;
 	uint8_t laddr = addr - p->r_usbcon;
-	uint8_t v;
+	uint8_t v = 0;
 	struct _epstate * epstate = get_epstate(p, current_ep_to_cpu(p));
 
 	switch(laddr) {

--- a/simavr/sim/sim_interrupts.c
+++ b/simavr/sim/sim_interrupts.c
@@ -114,9 +114,9 @@ avr_raise_interrupt(
 		return 0;
 	if (vector->pending) {
 		if (vector->trace)
-			printf("IRQ%"PRId8":I=%d already raised (enabled %"PRId8") (cycle %"PRId64" pc 0x%"PRIx32")\n",
+			printf("IRQ%"PRId8":I=%d already raised (enabled %"PRId8") (cycle %"PRIu64" pc 0x%"PRIx32")\n",
 				vector->vector, !!avr->sreg[S_I], avr_regbit_get(avr, vector->enable),
-				(long long int)avr->cycle, avr->pc);
+				avr->cycle, avr->pc);
 		return 0;
 	}
 	if (vector->trace)

--- a/simavr/sim/sim_interrupts.c
+++ b/simavr/sim/sim_interrupts.c
@@ -24,6 +24,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <strings.h>
+#include <inttypes.h>
 #include "sim_interrupts.h"
 #include "sim_avr.h"
 #include "sim_core.h"
@@ -72,11 +73,11 @@ avr_register_vector(
 			AVR_INT_IRQ_COUNT, names);
 	table->vector[table->vector_count++] = vector;
 	if (vector->trace)
-		printf("IRQ%d registered (enabled %04x:%d)\n",
+		printf("IRQ%"PRId8" registered (enabled %04"PRIx32":%"PRId32")\n",
 			vector->vector, vector->enable.reg, vector->enable.bit);
 
 	if (!vector->enable.reg)
-		AVR_LOG(avr, LOG_WARNING, "IRQ%d No 'enable' bit !\n",
+		AVR_LOG(avr, LOG_WARNING, "IRQ%"PRId8" No 'enable' bit !\n",
 			vector->vector);
 }
 
@@ -113,13 +114,13 @@ avr_raise_interrupt(
 		return 0;
 	if (vector->pending) {
 		if (vector->trace)
-			printf("IRQ%d:I=%d already raised (enabled %d) (cycle %lld pc 0x%x)\n",
+			printf("IRQ%"PRId8":I=%d already raised (enabled %"PRId8") (cycle %"PRId64" pc 0x%"PRIx32")\n",
 				vector->vector, !!avr->sreg[S_I], avr_regbit_get(avr, vector->enable),
 				(long long int)avr->cycle, avr->pc);
 		return 0;
 	}
 	if (vector->trace)
-		printf("IRQ%d raising (enabled %d)\n",
+		printf("IRQ%"PRId8" raising (enabled %"PRId8")\n",
 			vector->vector, avr_regbit_get(avr, vector->enable));
 	// always mark the 'raised' flag to one, even if the interrupt is disabled
 	// this allow "polling" for the "raised" flag, like for non-interrupt
@@ -143,7 +144,7 @@ avr_raise_interrupt(
 			avr->interrupt_state = 1;
 		if (avr->state == cpu_Sleeping) {
 			if (vector->trace)
-				printf("IRQ%d Waking CPU due to interrupt\n",
+				printf("IRQ%"PRId8" Waking CPU due to interrupt\n",
 					vector->vector);
 			avr->state = cpu_Running;	// in case we were sleeping
 		}
@@ -160,7 +161,7 @@ avr_clear_interrupt(
 	if (!vector)
 		return;
 	if (vector->trace)
-		printf("IRQ%d cleared\n", vector->vector);
+		printf("IRQ%"PRId8" cleared\n", vector->vector);
 	vector->pending = 0;
 
 	avr_raise_irq(vector->irq + AVR_INT_IRQ_PENDING, 0);
@@ -269,7 +270,7 @@ avr_service_interrupts(
 		avr->interrupt_state = avr_has_pending_interrupts(avr);
 	} else {
 		if (vector && vector->trace)
-			printf("IRQ%d calling\n", vector->vector);
+			printf("IRQ%"PRId8" calling\n", vector->vector);
 		_avr_push_addr(avr, avr->pc);
 		avr_sreg_set(avr, S_I, 0);
 		avr->pc = vector->vector * avr->vector_size;

--- a/simavr/sim/sim_network.h
+++ b/simavr/sim/sim_network.h
@@ -30,8 +30,8 @@ extern "C" {
 
 // Windows with MinGW
 
-#include <windows.h>
 #include <winsock2.h>
+#include <windows.h>
 #include <ws2tcpip.h>
 
 #define send(sockfd, buf, len, flags) \

--- a/simavr/sim/sim_utils.c
+++ b/simavr/sim/sim_utils.c
@@ -66,3 +66,16 @@ argv_parse(
 	argv->argv[argv->argc] = NULL;
 	return argv;
 }
+
+#ifdef __MINGW32__
+char * strsep(char **sp, char *sep)
+{
+	char *p, *s;
+	if (sp == NULL || *sp == NULL || **sp == '\0') return(NULL);
+	s = *sp;
+	p = s + strcspn(s, sep);
+	if (*p != '\0') *p++ = '\0';
+	*sp = p;
+	return(s);
+}
+#endif

--- a/simavr/sim/sim_utils.h
+++ b/simavr/sim/sim_utils.h
@@ -26,6 +26,7 @@
 #define __SIM_UTILS_H__
 
 #include <stdint.h>
+#include <string.h>
 
 typedef struct argv_t {
 	uint32_t size, argc;
@@ -47,5 +48,14 @@ argv_p
 argv_parse(
 	argv_p	argv,
 	char * line );
+
+#ifdef __MINGW32__
+/*
+ * There is no strsep function in MinGW library.
+ * The one implemented here comes from public domain:
+ * http://unixpapa.com/incnote/string.html
+ */
+char * strsep(char **sp, char *sep);
+#endif
 
 #endif /* __SIM_UTILS_H__ */


### PR DESCRIPTION
Bunch of fixes that makes it possible to compile the simavr in mingw-w64. I am using MSYS2 distribution locally.

Please forget about old and abandoned mingw compiller. MinGW-w64 is direct continuation of mingw and should be used for new projects.