### PR TITLE
Add reset flags and set power-on reset as a default when avr is initialised

### DIFF
--- a/simavr/cores/sim_core_declare.h
+++ b/simavr/cores/sim_core_declare.h
@@ -71,6 +71,12 @@
 # define _FUSE_HELPER { 0 }
 #endif
 
+#ifdef MCUSR
+# define MCU_STATUS_REG MCUSR
+#else
+# define MCU_STATUS_REG MCUCSR
+#endif
+
 #ifdef SIGNATURE_0
 #define DEFAULT_CORE(_vector_size) \
 	.ramend = RAMEND, \
@@ -79,7 +85,13 @@
 	.vector_size = _vector_size, \
 	.fuse = _FUSE_HELPER, \
 	.signature = { SIGNATURE_0,SIGNATURE_1,SIGNATURE_2 }, \
-	.lockbits = 0xFF
+	.lockbits = 0xFF, \
+	.reset_flags = {\
+		.porf = AVR_IO_REGBIT(MCU_STATUS_REG, PORF),\
+		.extrf = AVR_IO_REGBIT(MCU_STATUS_REG, EXTRF),\
+		.borf = AVR_IO_REGBIT(MCU_STATUS_REG, BORF),\
+		.wdrf = AVR_IO_REGBIT(MCU_STATUS_REG, WDRF)\
+	}
 #else
 // Disable signature when using an old avr toolchain
 #define DEFAULT_CORE(_vector_size) \

--- a/simavr/sim/sim_avr.c
+++ b/simavr/sim/sim_avr.c
@@ -102,6 +102,7 @@ avr_init(
 	avr->address_size = avr->eind ? 3 : 2;
 	avr->log = 1;
 	avr_reset(avr);
+	avr_regbit_set(avr, avr->reset_flags.porf);		// by  default set to power-on reset
 	return 0;
 }
 

--- a/simavr/sim/sim_avr.h
+++ b/simavr/sim/sim_avr.h
@@ -159,6 +159,12 @@ typedef struct avr_t {
 	avr_io_addr_t		rampz;	// optional, only for ELPM/SPM on >64Kb cores
 	avr_io_addr_t		eind;	// optional, only for EIJMP/EICALL on >64Kb cores
 	uint8_t				address_size;	// 2, or 3 for cores >128KB in flash
+	struct {
+		avr_regbit_t		porf;
+		avr_regbit_t		extrf;
+		avr_regbit_t		borf;
+		avr_regbit_t		wdrf;
+	} reset_flags;
 
 	// filled by the ELF data, this allow tracking of invalid jumps
 	uint32_t			codeend;


### PR DESCRIPTION
http://www.atmel.com/images/doc2551.pdf

This application note has some recommendations for productiin quality firmware that uses watchdog timer. In particular, on page 11, the diagram recomnends checking MCUSR (MCUCSR on some) register for reset flags. If no reset flag is set then there was no genuine reset and the code ended up at address zero due to a bug.
In order to be able to test how furmware behaves with different reset conditions and, more importantly, get firmware that follows the above algo to work with simavr I suggest this pull request. It basically exposes some of the most common reset flags and also sets PORF (power-on reset flag) by default. 