### PR TITLE
Add analog comparator

### DIFF
--- a/simavr/cores/sim_90usb162.c
+++ b/simavr/cores/sim_90usb162.c
@@ -31,6 +31,7 @@
 #include "avr_timer.h"
 #include "avr_spi.h"
 #include "avr_usb.h"
+#include "avr_acomp.h"
 
 void usb162_init(struct avr_t * avr);
 void usb162_reset(struct avr_t * avr);
@@ -50,6 +51,7 @@ const struct mcu_t {
 	avr_timer_t		timer0,timer1;
 	avr_spi_t		spi;
 	avr_usb_t		usb;
+	avr_acomp_t		acomp;
 } mcu_usb162 = {
 	.core = {
 		.mmcu = "at90usb162",
@@ -212,6 +214,22 @@ const struct mcu_t {
 		.usb_com_vect=USB_COM_vect,
 		.usb_gen_vect=USB_GEN_vect,
 	},
+	.acomp = {
+		.r_acsr = ACSR,
+		.acis = { AVR_IO_REGBIT(ACSR, ACIS0), AVR_IO_REGBIT(ACSR, ACIS1) },
+		.acic = AVR_IO_REGBIT(ACSR, ACIC),
+		.aco = AVR_IO_REGBIT(ACSR, ACO),
+		.acbg = AVR_IO_REGBIT(ACSR, ACBG),
+		.disabled = AVR_IO_REGBIT(ACSR, ACD),
+
+		.timer_name = '1',
+
+		.ac = {
+			.enable = AVR_IO_REGBIT(ACSR, ACIE),
+			.raised = AVR_IO_REGBIT(ACSR, ACI),
+			.vector = ANALOG_COMP_vect,
+		}
+	}
 };
 
 static avr_t * make()
@@ -240,6 +258,7 @@ void usb162_init(struct avr_t * avr)
 	avr_timer_init(avr, &mcu->timer1);
 	avr_spi_init(avr, &mcu->spi);
 	avr_usb_init(avr, &mcu->usb);
+	avr_acomp_init(avr, &mcu->acomp);
 }
 
 void usb162_reset(struct avr_t * avr)

--- a/simavr/cores/sim_mega128.c
+++ b/simavr/cores/sim_mega128.c
@@ -31,6 +31,7 @@
 #include "avr_timer.h"
 #include "avr_spi.h"
 #include "avr_twi.h"
+#include "avr_acomp.h"
 
 void m128_init(struct avr_t * avr);
 void m128_reset(struct avr_t * avr);
@@ -50,6 +51,7 @@ const struct mcu_t {
 	avr_extint_t	extint;
 	avr_ioport_t	porta, portb, portc, portd, porte, portf, portg;
 	avr_uart_t		uart0,uart1;
+	avr_acomp_t		acomp;
 	avr_adc_t		adc;
 	avr_timer_t		timer0,timer1,timer2,timer3;
 	avr_spi_t		spi;
@@ -88,6 +90,29 @@ const struct mcu_t {
 	// no PRUSART
 	AVR_UARTX_DECLARE(0, 0, 0),
 	AVR_UARTX_DECLARE(1, 0, 0),
+
+	.acomp = {
+		.mux_inputs = 8,
+		.mux = { AVR_IO_REGBIT(ADMUX, MUX0), AVR_IO_REGBIT(ADMUX, MUX1),
+				AVR_IO_REGBIT(ADMUX, MUX2) },
+		.aden = AVR_IO_REGBIT(ADCSRA, ADEN),
+		.acme = AVR_IO_REGBIT(SFIOR, ACME),
+
+		.r_acsr = ACSR,
+		.acis = { AVR_IO_REGBIT(ACSR, ACIS0), AVR_IO_REGBIT(ACSR, ACIS1) },
+		.acic = AVR_IO_REGBIT(ACSR, ACIC),
+		.aco = AVR_IO_REGBIT(ACSR, ACO),
+		.acbg = AVR_IO_REGBIT(ACSR, ACBG),
+		.disabled = AVR_IO_REGBIT(ACSR, ACD),
+
+		.timer_name = '1',
+
+		.ac = {
+			.enable = AVR_IO_REGBIT(ACSR, ACIE),
+			.raised = AVR_IO_REGBIT(ACSR, ACI),
+			.vector = ANALOG_COMP_vect,
+		}
+	},
 
 	.adc = {
 		.r_admux = ADMUX,
@@ -421,6 +446,7 @@ void m128_init(struct avr_t * avr)
 	avr_ioport_init(avr, &mcu->portg);
 	avr_uart_init(avr, &mcu->uart0);
 	avr_uart_init(avr, &mcu->uart1);
+	avr_acomp_init(avr, &mcu->acomp);
 	avr_adc_init(avr, &mcu->adc);
 	avr_timer_init(avr, &mcu->timer0);
 	avr_timer_init(avr, &mcu->timer1);

--- a/simavr/cores/sim_mega1280.c
+++ b/simavr/cores/sim_mega1280.c
@@ -31,6 +31,7 @@
 #include "avr_timer.h"
 #include "avr_spi.h"
 #include "avr_twi.h"
+#include "avr_acomp.h"
 
 void m1280_init(struct avr_t * avr);
 void m1280_reset(struct avr_t * avr);
@@ -54,6 +55,7 @@ const struct mcu_t {
 	avr_ioport_t	porta, portb, portc, portd, porte, portf, portg, porth, portj, portk, portl;
 	avr_uart_t		uart0,uart1;
 	avr_uart_t		uart2,uart3;
+	avr_acomp_t		acomp;
 	avr_adc_t		adc;
 	avr_timer_t		timer0,timer1,timer2,timer3,timer4,timer5;
 	avr_spi_t		spi;
@@ -105,6 +107,30 @@ const struct mcu_t {
 	AVR_UARTX_DECLARE(1, PRR1, PRUSART1),
 	AVR_UARTX_DECLARE(2, PRR1, PRUSART2),
 	AVR_UARTX_DECLARE(3, PRR1, PRUSART3),
+
+	.acomp = {
+		.mux_inputs = 16,
+		.mux = { AVR_IO_REGBIT(ADMUX, MUX0), AVR_IO_REGBIT(ADMUX, MUX1),
+				AVR_IO_REGBIT(ADMUX, MUX2), AVR_IO_REGBIT(ADCSRB, MUX5) },
+		.pradc = AVR_IO_REGBIT(PRR0, PRADC),
+		.aden = AVR_IO_REGBIT(ADCSRA, ADEN),
+		.acme = AVR_IO_REGBIT(ADCSRB, ACME),
+
+		.r_acsr = ACSR,
+		.acis = { AVR_IO_REGBIT(ACSR, ACIS0), AVR_IO_REGBIT(ACSR, ACIS1) },
+		.acic = AVR_IO_REGBIT(ACSR, ACIC),
+		.aco = AVR_IO_REGBIT(ACSR, ACO),
+		.acbg = AVR_IO_REGBIT(ACSR, ACBG),
+		.disabled = AVR_IO_REGBIT(ACSR, ACD),
+
+		.timer_name = '1',
+
+		.ac = {
+			.enable = AVR_IO_REGBIT(ACSR, ACIE),
+			.raised = AVR_IO_REGBIT(ACSR, ACI),
+			.vector = ANALOG_COMP_vect,
+		}
+	},
 
 	.adc = {
 		.r_admux = ADMUX,
@@ -652,6 +678,7 @@ void m1280_init(struct avr_t * avr)
 	avr_uart_init(avr, &mcu->uart1);
 	avr_uart_init(avr, &mcu->uart2);
 	avr_uart_init(avr, &mcu->uart3);
+	avr_acomp_init(avr, &mcu->acomp);
 	avr_adc_init(avr, &mcu->adc);
 	avr_timer_init(avr, &mcu->timer0);
 	avr_timer_init(avr, &mcu->timer1);

--- a/simavr/cores/sim_mega1281.c
+++ b/simavr/cores/sim_mega1281.c
@@ -31,6 +31,7 @@
 #include "avr_timer.h"
 #include "avr_spi.h"
 #include "avr_twi.h"
+#include "avr_acomp.h"
 
 void m1281_init(struct avr_t * avr);
 void m1281_reset(struct avr_t * avr);
@@ -50,6 +51,7 @@ const struct mcu_t {
 	avr_extint_t	extint;
 	avr_ioport_t	porta, portb, portc, portd, porte, portf, portg;
 	avr_uart_t		uart0,uart1;
+	avr_acomp_t		acomp;
 	avr_adc_t		adc;
 	avr_timer_t		timer0,timer1,timer2,timer3;
 	avr_spi_t		spi;
@@ -95,6 +97,30 @@ const struct mcu_t {
 
 	AVR_UARTX_DECLARE(0, PRR0, PRUSART0),
 	AVR_UARTX_DECLARE(1, PRR1, PRUSART1),
+
+	.acomp = {
+		.mux_inputs = 8,
+		.mux = { AVR_IO_REGBIT(ADMUX, MUX0), AVR_IO_REGBIT(ADMUX, MUX1),
+				AVR_IO_REGBIT(ADMUX, MUX2) },
+		.pradc = AVR_IO_REGBIT(PRR0, PRADC),
+		.aden = AVR_IO_REGBIT(ADCSRA, ADEN),
+		.acme = AVR_IO_REGBIT(ADCSRB, ACME),
+
+		.r_acsr = ACSR,
+		.acis = { AVR_IO_REGBIT(ACSR, ACIS0), AVR_IO_REGBIT(ACSR, ACIS1) },
+		.acic = AVR_IO_REGBIT(ACSR, ACIC),
+		.aco = AVR_IO_REGBIT(ACSR, ACO),
+		.acbg = AVR_IO_REGBIT(ACSR, ACBG),
+		.disabled = AVR_IO_REGBIT(ACSR, ACD),
+
+		.timer_name = '1',
+
+		.ac = {
+			.enable = AVR_IO_REGBIT(ACSR, ACIE),
+			.raised = AVR_IO_REGBIT(ACSR, ACI),
+			.vector = ANALOG_COMP_vect,
+		}
+	},
 
 	.adc = {
 		.r_admux = ADMUX,
@@ -460,6 +486,7 @@ void m1281_init(struct avr_t * avr)
 	avr_ioport_init(avr, &mcu->portg);
 	avr_uart_init(avr, &mcu->uart0);
 	avr_uart_init(avr, &mcu->uart1);
+	avr_acomp_init(avr, &mcu->acomp);
 	avr_adc_init(avr, &mcu->adc);
 	avr_timer_init(avr, &mcu->timer0);
 	avr_timer_init(avr, &mcu->timer1);

--- a/simavr/cores/sim_mega128rfa1.c
+++ b/simavr/cores/sim_mega128rfa1.c
@@ -33,6 +33,7 @@
 #include "avr_timer.h"
 #include "avr_spi.h"
 #include "avr_twi.h"
+#include "avr_acomp.h"
 
 void m128rfa1_init(struct avr_t * avr);
 void m128rfa1_reset(struct avr_t * avr);
@@ -52,6 +53,7 @@ const struct mcu_t {
 	avr_extint_t	extint;
 	avr_ioport_t	portb, portd, porte, portf, portg;
 	avr_uart_t		uart0,uart1;
+	avr_acomp_t		acomp;
 	avr_adc_t		adc;
 	avr_timer_t		timer0,timer1,timer2,timer3;
 	avr_spi_t		spi;
@@ -103,6 +105,30 @@ const struct mcu_t {
 
 	AVR_UARTX_DECLARE(0, PRR0, PRUSART0),
 	AVR_UARTX_DECLARE(1, PRR1, PRUSART1),
+
+	.acomp = {
+		.mux_inputs = 8,
+		.mux = { AVR_IO_REGBIT(ADMUX, MUX0), AVR_IO_REGBIT(ADMUX, MUX1),
+				AVR_IO_REGBIT(ADMUX, MUX2), AVR_IO_REGBIT(ADCSRB, MUX5) },
+		.pradc = AVR_IO_REGBIT(PRR0, PRADC),
+		.aden = AVR_IO_REGBIT(ADCSRA, ADEN),
+		.acme = AVR_IO_REGBIT(ADCSRB, ACME),
+
+		.r_acsr = ACSR,
+		.acis = { AVR_IO_REGBIT(ACSR, ACIS0), AVR_IO_REGBIT(ACSR, ACIS1) },
+		.acic = AVR_IO_REGBIT(ACSR, ACIC),
+		.aco = AVR_IO_REGBIT(ACSR, ACO),
+		.acbg = AVR_IO_REGBIT(ACSR, ACBG),
+		.disabled = AVR_IO_REGBIT(ACSR, ACD),
+
+		.timer_name = '1',
+
+		.ac = {
+			.enable = AVR_IO_REGBIT(ACSR, ACIE),
+			.raised = AVR_IO_REGBIT(ACSR, ACI),
+			.vector = ANALOG_COMP_vect,
+		}
+	},
 
 	.adc = {
 		.r_admux = ADMUX,
@@ -487,6 +513,7 @@ void m128rfa1_init(struct avr_t * avr)
 	avr_ioport_init(avr, &mcu->portg);
 	avr_uart_init(avr, &mcu->uart0);
 	avr_uart_init(avr, &mcu->uart1);
+	avr_acomp_init(avr, &mcu->acomp);
 	avr_adc_init(avr, &mcu->adc);
 	avr_timer_init(avr, &mcu->timer0);
 	avr_timer_init(avr, &mcu->timer1);

--- a/simavr/cores/sim_mega128rfr2.c
+++ b/simavr/cores/sim_mega128rfr2.c
@@ -33,6 +33,7 @@
 #include "avr_timer.h"
 #include "avr_spi.h"
 #include "avr_twi.h"
+#include "avr_acomp.h"
 
 void m128rfr2_init(struct avr_t * avr);
 void m128rfr2_reset(struct avr_t * avr);
@@ -78,6 +79,7 @@ const struct mcu_t {
 	avr_extint_t	extint;
 	avr_ioport_t	portb, portd, porte, portf, portg;
 	avr_uart_t		uart0,uart1;
+	avr_acomp_t		acomp;
 	avr_adc_t		adc;
 	avr_timer_t		timer0,timer1,timer2,timer3;
 	avr_spi_t		spi;
@@ -129,6 +131,30 @@ const struct mcu_t {
 
 	AVR_UARTX_DECLARE(0, PRR0, PRUSART0),
 	AVR_UARTX_DECLARE(1, PRR1, PRUSART1),
+
+	.acomp = {
+		.mux_inputs = 8,
+		.mux = { AVR_IO_REGBIT(ADMUX, MUX0), AVR_IO_REGBIT(ADMUX, MUX1),
+				AVR_IO_REGBIT(ADMUX, MUX2), AVR_IO_REGBIT(ADCSRB, MUX5) },
+		.pradc = AVR_IO_REGBIT(PRR0, PRADC),
+		.aden = AVR_IO_REGBIT(ADCSRA, ADEN),
+		.acme = AVR_IO_REGBIT(ADCSRB, ACME),
+
+		.r_acsr = ACSR,
+		.acis = { AVR_IO_REGBIT(ACSR, ACIS0), AVR_IO_REGBIT(ACSR, ACIS1) },
+		.acic = AVR_IO_REGBIT(ACSR, ACIC),
+		.aco = AVR_IO_REGBIT(ACSR, ACO),
+		.acbg = AVR_IO_REGBIT(ACSR, ACBG),
+		.disabled = AVR_IO_REGBIT(ACSR, ACD),
+
+		.timer_name = '1',
+
+		.ac = {
+			.enable = AVR_IO_REGBIT(ACSR, ACIE),
+			.raised = AVR_IO_REGBIT(ACSR, ACI),
+			.vector = ANALOG_COMP_vect,
+		}
+	},
 
 	.adc = {
 		.r_admux = ADMUX,
@@ -496,6 +522,7 @@ void m128rfr2_init(struct avr_t * avr)
 	avr_ioport_init(avr, &mcu->portg);
 	avr_uart_init(avr, &mcu->uart0);
 	avr_uart_init(avr, &mcu->uart1);
+	avr_acomp_init(avr, &mcu->acomp);
 	avr_adc_init(avr, &mcu->adc);
 	avr_timer_init(avr, &mcu->timer0);
 	avr_timer_init(avr, &mcu->timer1);

--- a/simavr/cores/sim_mega169.c
+++ b/simavr/cores/sim_mega169.c
@@ -14,6 +14,7 @@
 #include "avr_timer.h"
 #include "avr_spi.h"
 #include "avr_twi.h"
+#include "avr_acomp.h"
 
 void m169p_init(struct avr_t * avr);
 void m169p_reset(struct avr_t * avr);
@@ -37,6 +38,7 @@ const struct mcu_t {
 	avr_extint_t	extint;
 	avr_ioport_t	porta, portb, portc, portd, porte, portf, portg;
 	avr_uart_t		uart0;
+	avr_acomp_t		acomp;
 	avr_adc_t		adc;
 	avr_timer_t		timer0,timer1,timer2;
 	avr_spi_t		spi;
@@ -78,6 +80,30 @@ const struct mcu_t {
 	AVR_IOPORT_DECLARE(g, 'G', G),
 
 	AVR_UARTX_DECLARE(0, PRR, PRUSART0),
+
+	.acomp = {
+		.mux_inputs = 8,
+		.mux = { AVR_IO_REGBIT(ADMUX, MUX0), AVR_IO_REGBIT(ADMUX, MUX1),
+				AVR_IO_REGBIT(ADMUX, MUX2) },
+		.pradc = AVR_IO_REGBIT(PRR, PRADC),
+		.aden = AVR_IO_REGBIT(ADCSRA, ADEN),
+		.acme = AVR_IO_REGBIT(ADCSRB, ACME),
+
+		.r_acsr = ACSR,
+		.acis = { AVR_IO_REGBIT(ACSR, ACIS0), AVR_IO_REGBIT(ACSR, ACIS1) },
+		.acic = AVR_IO_REGBIT(ACSR, ACIC),
+		.aco = AVR_IO_REGBIT(ACSR, ACO),
+		.acbg = AVR_IO_REGBIT(ACSR, ACBG),
+		.disabled = AVR_IO_REGBIT(ACSR, ACD),
+
+		.timer_name = '1',
+
+		.ac = {
+			.enable = AVR_IO_REGBIT(ACSR, ACIE),
+			.raised = AVR_IO_REGBIT(ACSR, ACI),
+			.vector = ANALOG_COMP_vect,
+		}
+	},
 
 	.adc = {
 		.r_admux = ADMUX,
@@ -322,6 +348,7 @@ void m169p_init(struct avr_t * avr)
 	avr_ioport_init(avr, &mcu->portg);
 
 	avr_uart_init(avr, &mcu->uart0);
+	avr_acomp_init(avr, &mcu->acomp);
 	avr_adc_init(avr, &mcu->adc);
 	avr_timer_init(avr, &mcu->timer0);
 	avr_timer_init(avr, &mcu->timer1);

--- a/simavr/cores/sim_mega2560.c
+++ b/simavr/cores/sim_mega2560.c
@@ -32,6 +32,7 @@
 #include "avr_timer.h"
 #include "avr_spi.h"
 #include "avr_twi.h"
+#include "avr_acomp.h"
 
 void m2560_init(struct avr_t * avr);
 void m2560_reset(struct avr_t * avr);
@@ -55,6 +56,7 @@ const struct mcu_t {
 	avr_ioport_t	porta, portb, portc, portd, porte, portf, portg, porth, portj, portk, portl;
 	avr_uart_t		uart0,uart1;
 	avr_uart_t		uart2,uart3;
+	avr_acomp_t		acomp;
 	avr_adc_t		adc;
 	avr_timer_t		timer0,timer1,timer2,timer3,timer4,timer5;
 	avr_spi_t		spi;
@@ -107,6 +109,30 @@ const struct mcu_t {
 	AVR_UARTX_DECLARE(1, PRR1, PRUSART1),
 	AVR_UARTX_DECLARE(2, PRR1, PRUSART2),
 	AVR_UARTX_DECLARE(3, PRR1, PRUSART3),
+
+	.acomp = {
+		.mux_inputs = 16,
+		.mux = { AVR_IO_REGBIT(ADMUX, MUX0), AVR_IO_REGBIT(ADMUX, MUX1),
+				AVR_IO_REGBIT(ADMUX, MUX2), AVR_IO_REGBIT(ADCSRB, MUX5) },
+		.pradc = AVR_IO_REGBIT(PRR0, PRADC),
+		.aden = AVR_IO_REGBIT(ADCSRA, ADEN),
+		.acme = AVR_IO_REGBIT(ADCSRB, ACME),
+
+		.r_acsr = ACSR,
+		.acis = { AVR_IO_REGBIT(ACSR, ACIS0), AVR_IO_REGBIT(ACSR, ACIS1) },
+		.acic = AVR_IO_REGBIT(ACSR, ACIC),
+		.aco = AVR_IO_REGBIT(ACSR, ACO),
+		.acbg = AVR_IO_REGBIT(ACSR, ACBG),
+		.disabled = AVR_IO_REGBIT(ACSR, ACD),
+
+		.timer_name = '1',
+
+		.ac = {
+			.enable = AVR_IO_REGBIT(ACSR, ACIE),
+			.raised = AVR_IO_REGBIT(ACSR, ACI),
+			.vector = ANALOG_COMP_vect,
+		}
+	},
 
 	.adc = {
 		.r_admux = ADMUX,

--- a/simavr/cores/sim_megax.c
+++ b/simavr/cores/sim_megax.c
@@ -38,6 +38,7 @@ void mx_init(struct avr_t * avr)
 	avr_ioport_init(avr, &mcu->portc);
 	avr_ioport_init(avr, &mcu->portd);
 	avr_uart_init(avr, &mcu->uart);
+	avr_acomp_init(avr, &mcu->acomp);
 	avr_adc_init(avr, &mcu->adc);
 	avr_timer_init(avr, &mcu->timer0);
 	avr_timer_init(avr, &mcu->timer1);

--- a/simavr/cores/sim_megax.h
+++ b/simavr/cores/sim_megax.h
@@ -33,6 +33,8 @@
 #include "avr_timer.h"
 #include "avr_spi.h"
 #include "avr_twi.h"
+#include "avr_acomp.h"
+
 
 void mx_init(struct avr_t * avr);
 void mx_reset(struct avr_t * avr);
@@ -48,6 +50,7 @@ struct mcu_t {
 	avr_extint_t	extint;
 	avr_ioport_t	portb, portc, portd;
 	avr_uart_t		uart;
+	avr_acomp_t		acomp;
 	avr_adc_t		adc;
 	avr_timer_t		timer0,timer1,timer2;
 	avr_spi_t		spi;
@@ -101,6 +104,29 @@ const struct mcu_t SIM_CORENAME = {
 
 	//no PRUSART, upe=PE, no reg/bit name index, 'C' in RX/TX vector names
 	AVR_UART_DECLARE(0, 0, PE, , C),
+
+	.acomp = {
+		.mux_inputs = 8,
+		.mux = { AVR_IO_REGBIT(ADMUX, MUX0), AVR_IO_REGBIT(ADMUX, MUX1),
+				AVR_IO_REGBIT(ADMUX, MUX2) },
+		.aden = AVR_IO_REGBIT(ADCSRA, ADEN),
+		.acme = AVR_IO_REGBIT(SFIOR, ACME),
+
+		.r_acsr = ACSR,
+		.acis = { AVR_IO_REGBIT(ACSR, ACIS0), AVR_IO_REGBIT(ACSR, ACIS1) },
+		.acic = AVR_IO_REGBIT(ACSR, ACIC),
+		.aco = AVR_IO_REGBIT(ACSR, ACO),
+		.acbg = AVR_IO_REGBIT(ACSR, ACBG),
+		.disabled = AVR_IO_REGBIT(ACSR, ACD),
+
+		.timer_name = '1',
+
+		.ac = {
+			.enable = AVR_IO_REGBIT(ACSR, ACIE),
+			.raised = AVR_IO_REGBIT(ACSR, ACI),
+			.vector = ANA_COMP_vect,
+		}
+	},
 
 	.adc = {
 		.r_admux = ADMUX,

--- a/simavr/cores/sim_megax4.c
+++ b/simavr/cores/sim_megax4.c
@@ -37,6 +37,7 @@ void mx4_init(struct avr_t * avr)
 	avr_ioport_init(avr, &mcu->portd);
 	avr_uart_init(avr, &mcu->uart0);
 	avr_uart_init(avr, &mcu->uart1);
+	avr_acomp_init(avr, &mcu->acomp);
 	avr_adc_init(avr, &mcu->adc);
 	avr_timer_init(avr, &mcu->timer0);
 	avr_timer_init(avr, &mcu->timer1);

--- a/simavr/cores/sim_megax4.h
+++ b/simavr/cores/sim_megax4.h
@@ -34,6 +34,7 @@
 #include "avr_timer.h"
 #include "avr_spi.h"
 #include "avr_twi.h"
+#include "avr_acomp.h"
 
 void mx4_init(struct avr_t * avr);
 void mx4_reset(struct avr_t * avr);
@@ -49,6 +50,7 @@ struct mcu_t {
 	avr_extint_t	extint;
 	avr_ioport_t	porta, portb, portc, portd;
 	avr_uart_t		uart0,uart1;
+	avr_acomp_t		acomp;
 	avr_adc_t		adc;
 	avr_timer_t		timer0,timer1,timer2;
 	avr_timer_t 	timer3;
@@ -130,6 +132,30 @@ const struct mcu_t SIM_CORENAME = {
 
 	AVR_UARTX_DECLARE(0, PRR0, PRUSART0),
 	AVR_UARTX_DECLARE(1, PRR0, PRUSART1),
+
+	.acomp = {
+		.mux_inputs = 8,
+		.mux = { AVR_IO_REGBIT(ADMUX, MUX0), AVR_IO_REGBIT(ADMUX, MUX1),
+				AVR_IO_REGBIT(ADMUX, MUX2) },
+		.pradc = AVR_IO_REGBIT(PRR0, PRADC),
+		.aden = AVR_IO_REGBIT(ADCSRA, ADEN),
+		.acme = AVR_IO_REGBIT(ADCSRB, ACME),
+
+		.r_acsr = ACSR,
+		.acis = { AVR_IO_REGBIT(ACSR, ACIS0), AVR_IO_REGBIT(ACSR, ACIS1) },
+		.acic = AVR_IO_REGBIT(ACSR, ACIC),
+		.aco = AVR_IO_REGBIT(ACSR, ACO),
+		.acbg = AVR_IO_REGBIT(ACSR, ACBG),
+		.disabled = AVR_IO_REGBIT(ACSR, ACD),
+
+		.timer_name = '1',
+
+		.ac = {
+			.enable = AVR_IO_REGBIT(ACSR, ACIE),
+			.raised = AVR_IO_REGBIT(ACSR, ACI),
+			.vector = ANALOG_COMP_vect,
+		}
+	},
 
 	.adc = {
 	//	.disabled = AVR_IO_REGBIT(PRR0,PRADC),

--- a/simavr/cores/sim_megax8.c
+++ b/simavr/cores/sim_megax8.c
@@ -35,6 +35,7 @@ void mx8_init(struct avr_t * avr)
 	avr_ioport_init(avr, &mcu->portc);
 	avr_ioport_init(avr, &mcu->portd);
 	avr_uart_init(avr, &mcu->uart);
+	avr_acomp_init(avr, &mcu->acomp);
 	avr_adc_init(avr, &mcu->adc);
 	avr_timer_init(avr, &mcu->timer0);
 	avr_timer_init(avr, &mcu->timer1);

--- a/simavr/cores/sim_megax8.h
+++ b/simavr/cores/sim_megax8.h
@@ -34,6 +34,7 @@
 #include "avr_timer.h"
 #include "avr_spi.h"
 #include "avr_twi.h"
+#include "avr_acomp.h"
 
 void mx8_init(struct avr_t * avr);
 void mx8_reset(struct avr_t * avr);
@@ -49,6 +50,7 @@ struct mcu_t {
 	avr_extint_t	extint;
 	avr_ioport_t	portb,portc,portd;
 	avr_uart_t		uart;
+	avr_acomp_t		acomp;
 	avr_adc_t		adc;
 	avr_timer_t		timer0,timer1,timer2;
 	avr_spi_t		spi;
@@ -120,6 +122,29 @@ const struct mcu_t SIM_CORENAME = {
 	//PRR/PRUSART0, upe=UPE, reg/bit name index=0, no 'C' in RX/TX vector names
 	AVR_UART_DECLARE(PRR, PRUSART0, UPE, 0, ),
 
+	.acomp = {
+		.mux_inputs = 8,
+		.mux = { AVR_IO_REGBIT(ADMUX, MUX0), AVR_IO_REGBIT(ADMUX, MUX1),
+				AVR_IO_REGBIT(ADMUX, MUX2) },
+		.pradc = AVR_IO_REGBIT(PRR, PRADC),
+		.aden = AVR_IO_REGBIT(ADCSRA, ADEN),
+		.acme = AVR_IO_REGBIT(ADCSRB, ACME),
+
+		.r_acsr = ACSR,
+		.acis = { AVR_IO_REGBIT(ACSR, ACIS0), AVR_IO_REGBIT(ACSR, ACIS1) },
+		.acic = AVR_IO_REGBIT(ACSR, ACIC),
+		.aco = AVR_IO_REGBIT(ACSR, ACO),
+		.acbg = AVR_IO_REGBIT(ACSR, ACBG),
+		.disabled = AVR_IO_REGBIT(ACSR, ACD),
+
+		.timer_name = '1',
+
+		.ac = {
+			.enable = AVR_IO_REGBIT(ACSR, ACIE),
+			.raised = AVR_IO_REGBIT(ACSR, ACI),
+			.vector = ANALOG_COMP_vect,
+		}
+	},
 	.adc = {
 		.r_admux = ADMUX,
 		.mux = { AVR_IO_REGBIT(ADMUX, MUX0), AVR_IO_REGBIT(ADMUX, MUX1),

--- a/simavr/cores/sim_tiny13.c
+++ b/simavr/cores/sim_tiny13.c
@@ -28,6 +28,7 @@
 #include "avr_ioport.h"
 #include "avr_timer.h"
 #include "avr_adc.h"
+#include "avr_acomp.h"
 
 #define _AVR_IO_H_
 #define __ASSEMBLER__
@@ -44,6 +45,7 @@ static const struct mcu_t {
 	avr_extint_t	extint;
 	avr_ioport_t	portb;
 	avr_timer_t		timer0;
+	avr_acomp_t		acomp;
 	avr_adc_t       adc;
 } mcu = {
 	.core = {
@@ -119,6 +121,26 @@ static const struct mcu_t {
 			}
 		}
 	},
+
+	.acomp = {
+		.mux_inputs = 4,
+		.mux = { AVR_IO_REGBIT(ADMUX, MUX0), AVR_IO_REGBIT(ADMUX, MUX1) },
+		.aden = AVR_IO_REGBIT(ADCSRA, ADEN),
+		.acme = AVR_IO_REGBIT(ADCSRB, ACME),
+
+		.r_acsr = ACSR,
+		.acis = { AVR_IO_REGBIT(ACSR, ACIS0), AVR_IO_REGBIT(ACSR, ACIS1) },
+		.aco = AVR_IO_REGBIT(ACSR, ACO),
+		.acbg = AVR_IO_REGBIT(ACSR, ACBG),
+		.disabled = AVR_IO_REGBIT(ACSR, ACD),
+
+		.ac = {
+			.enable = AVR_IO_REGBIT(ACSR, ACIE),
+			.raised = AVR_IO_REGBIT(ACSR, ACI),
+			.vector = ANA_COMP_vect,
+		}
+	},
+
 	.adc = {
 		.r_admux = ADMUX,
 		.mux = { AVR_IO_REGBIT(ADMUX, MUX0),
@@ -185,6 +207,7 @@ static void init(struct avr_t * avr)
 	avr_extint_init(avr, &mcu->extint);
 	avr_ioport_init(avr, &mcu->portb);
 	avr_timer_init(avr, &mcu->timer0);
+	avr_acomp_init(avr, &mcu->acomp);
 	avr_adc_init(avr, &mcu->adc);
 }
 

--- a/simavr/cores/sim_tiny2313.c
+++ b/simavr/cores/sim_tiny2313.c
@@ -26,6 +26,7 @@
 #include "avr_ioport.h"
 #include "avr_uart.h"
 #include "avr_timer.h"
+#include "avr_acomp.h"
 
 static void init(struct avr_t * avr);
 static void reset(struct avr_t * avr);
@@ -45,6 +46,7 @@ static const struct mcu_t {
 	avr_ioport_t	porta, portb, portd;
 	avr_uart_t		uart;
 	avr_timer_t		timer0,timer1;
+	avr_acomp_t		acomp;
 } mcu = {
 	.core = {
 		.mmcu = "attiny2313",
@@ -178,7 +180,25 @@ static const struct mcu_t {
 				}
 			}
 		}
-	}
+	},
+
+	.acomp = {
+		.r_acsr = ACSR,
+		.acis = { AVR_IO_REGBIT(ACSR, ACIS0), AVR_IO_REGBIT(ACSR, ACIS1) },
+		.acic = AVR_IO_REGBIT(ACSR, ACIC),
+		.aco = AVR_IO_REGBIT(ACSR, ACO),
+		.acbg = AVR_IO_REGBIT(ACSR, ACBG),
+		.disabled = AVR_IO_REGBIT(ACSR, ACD),
+
+		.timer_name = '1',
+
+		.ac = {
+			.enable = AVR_IO_REGBIT(ACSR, ACIE),
+			.raised = AVR_IO_REGBIT(ACSR, ACI),
+			.vector = ANA_COMP_vect,
+		}
+	},
+
 };
 
 static avr_t * make()
@@ -204,6 +224,7 @@ static void init(struct avr_t * avr)
 	avr_uart_init(avr, &mcu->uart);
 	avr_timer_init(avr, &mcu->timer0);
 	avr_timer_init(avr, &mcu->timer1);
+	avr_acomp_init(avr, &mcu->acomp);
 }
 
 static void reset(struct avr_t * avr)

--- a/simavr/cores/sim_tinyx4.c
+++ b/simavr/cores/sim_tinyx4.c
@@ -33,6 +33,7 @@ void tx4_init(struct avr_t * avr)
     avr_extint_init(avr, &mcu->extint);
     avr_ioport_init(avr, &mcu->porta);
     avr_ioport_init(avr, &mcu->portb);
+    avr_acomp_init(avr, &mcu->acomp);
     avr_adc_init(avr, &mcu->adc);
     avr_timer_init(avr, &mcu->timer0);
     avr_timer_init(avr, &mcu->timer1);

--- a/simavr/cores/sim_tinyx4.h
+++ b/simavr/cores/sim_tinyx4.h
@@ -31,6 +31,7 @@
 #include "avr_ioport.h"
 #include "avr_adc.h"
 #include "avr_timer.h"
+#include "avr_acomp.h"
 
 void tx4_init(struct avr_t * avr);
 void tx4_reset(struct avr_t * avr);
@@ -44,6 +45,7 @@ struct mcu_t {
     avr_watchdog_t    watchdog;
     avr_extint_t    extint;
     avr_ioport_t    porta, portb;
+    avr_acomp_t		acomp;
     avr_adc_t        adc;
     avr_timer_t    timer0, timer1;
 };
@@ -88,6 +90,29 @@ const struct mcu_t SIM_CORENAME = {
         },
         .r_pcint = PCMSK1,
     },
+	.acomp = {
+		.mux_inputs = 8,
+		.mux = { AVR_IO_REGBIT(ADMUX, MUX0), AVR_IO_REGBIT(ADMUX, MUX1),
+				AVR_IO_REGBIT(ADMUX, MUX2) },
+		.pradc = AVR_IO_REGBIT(PRR, PRADC),
+		.aden = AVR_IO_REGBIT(ADCSRA, ADEN),
+		.acme = AVR_IO_REGBIT(ADCSRB, ACME),
+
+		.r_acsr = ACSR,
+		.acis = { AVR_IO_REGBIT(ACSR, ACIS0), AVR_IO_REGBIT(ACSR, ACIS1) },
+		.acic = AVR_IO_REGBIT(ACSR, ACIC),
+		.aco = AVR_IO_REGBIT(ACSR, ACO),
+		.acbg = AVR_IO_REGBIT(ACSR, ACBG),
+		.disabled = AVR_IO_REGBIT(ACSR, ACD),
+
+		.timer_name = '1',
+
+		.ac = {
+			.enable = AVR_IO_REGBIT(ACSR, ACIE),
+			.raised = AVR_IO_REGBIT(ACSR, ACI),
+			.vector = ANA_COMP_vect,
+		}
+	},
     .adc = {
         .r_admux = ADMUX,
         .mux = { AVR_IO_REGBIT(ADMUX, MUX0), AVR_IO_REGBIT(ADMUX, MUX1),

--- a/simavr/cores/sim_tinyx5.c
+++ b/simavr/cores/sim_tinyx5.c
@@ -32,6 +32,7 @@ void tx5_init(struct avr_t * avr)
 	avr_watchdog_init(avr, &mcu->watchdog);
 	avr_extint_init(avr, &mcu->extint);
 	avr_ioport_init(avr, &mcu->portb);
+	avr_acomp_init(avr, &mcu->acomp);
 	avr_adc_init(avr, &mcu->adc);
 	avr_timer_init(avr, &mcu->timer0);
 	avr_timer_init(avr, &mcu->timer1);

--- a/simavr/cores/sim_tinyx5.h
+++ b/simavr/cores/sim_tinyx5.h
@@ -31,6 +31,7 @@
 #include "avr_ioport.h"
 #include "avr_adc.h"
 #include "avr_timer.h"
+#include "avr_acomp.h"
 
 void tx5_init(struct avr_t * avr);
 void tx5_reset(struct avr_t * avr);
@@ -44,6 +45,7 @@ struct mcu_t {
 	avr_watchdog_t	watchdog;
 	avr_extint_t	extint;
 	avr_ioport_t	portb;
+	avr_acomp_t		acomp;
 	avr_adc_t		adc;
 	avr_timer_t	timer0, timer1;
 };
@@ -78,6 +80,26 @@ const struct mcu_t SIM_CORENAME = {
 			.vector = PCINT0_vect,
 		},
 		.r_pcint = PCMSK,
+	},
+	.acomp = {
+		.mux_inputs = 4,
+		.mux = { AVR_IO_REGBIT(ADMUX, MUX0), AVR_IO_REGBIT(ADMUX, MUX1),
+				AVR_IO_REGBIT(ADMUX, MUX2), AVR_IO_REGBIT(ADMUX, MUX3) },
+		.pradc = AVR_IO_REGBIT(PRR, PRADC),
+		.aden = AVR_IO_REGBIT(ADCSRA, ADEN),
+		.acme = AVR_IO_REGBIT(ADCSRB, ACME),
+
+		.r_acsr = ACSR,
+		.acis = { AVR_IO_REGBIT(ACSR, ACIS0), AVR_IO_REGBIT(ACSR, ACIS1) },
+		.aco = AVR_IO_REGBIT(ACSR, ACO),
+		.acbg = AVR_IO_REGBIT(ACSR, ACBG),
+		.disabled = AVR_IO_REGBIT(ACSR, ACD),
+
+		.ac = {
+			.enable = AVR_IO_REGBIT(ACSR, ACIE),
+			.raised = AVR_IO_REGBIT(ACSR, ACI),
+			.vector = ANA_COMP_vect,
+		}
 	},
 	.adc = {
 		.r_admux = ADMUX,

--- a/simavr/sim/avr_acomp.c
+++ b/simavr/sim/avr_acomp.c
@@ -1,0 +1,241 @@
+/*
+	avr_acomp.c
+
+	Copyright 2017 Konstantin Begun
+
+ 	This file is part of simavr.
+
+	simavr is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	simavr is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with simavr.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdlib.h>
+#include "avr_acomp.h"
+#include "avr_timer.h"
+
+static uint8_t
+avr_acomp_get_state(
+		struct avr_t * avr,
+		avr_acomp_t *ac)
+{
+	if (avr_regbit_get(avr, ac->disabled))
+		return 0;
+
+	// get positive voltage
+	uint16_t positive_v;
+
+	if (avr_regbit_get(avr, ac->acbg)) {		// if bandgap
+		positive_v = ACOMP_BANDGAP;
+	} else {
+		positive_v = ac->ain_values[0];	// AIN0
+	}
+
+	// get negative voltage
+	uint16_t negative_v = 0;
+
+	// multiplexer is enabled if acme is set and adc is off
+	if (avr_regbit_get(avr, ac->acme) && !avr_regbit_get(avr, ac->aden)) {
+		if (!avr_regbit_get(avr, ac->pradc)) {
+			uint8_t adc_i = avr_regbit_get_array(avr, ac->mux, ARRAY_SIZE(ac->mux));
+			if (adc_i < ac->mux_inputs && adc_i < ARRAY_SIZE(ac->adc_values)) {
+				negative_v = ac->adc_values[adc_i];
+			}
+		}
+
+	} else {
+		negative_v = ac->ain_values[1];	// AIN1
+	}
+
+	return positive_v > negative_v;
+}
+
+static avr_cycle_count_t
+avr_acomp_sync_state(
+	struct avr_t * avr,
+	avr_cycle_count_t when,
+	void * param)
+{
+	avr_acomp_t * p = (avr_acomp_t *)param;
+	if (!avr_regbit_get(avr, p->disabled)) {
+
+		uint8_t cur_state = avr_regbit_get(avr, p->aco);
+		uint8_t new_state = avr_acomp_get_state(avr, p);
+
+		if (new_state != cur_state) {
+			avr_regbit_setto(avr, p->aco, new_state);		// set ACO
+
+			uint8_t acis0 = avr_regbit_get(avr, p->acis[0]);
+			uint8_t acis1 = avr_regbit_get(avr, p->acis[1]);
+
+			if ((acis0 == 0 && acis1 == 0) || (acis1 == 1 && acis0 == new_state)) {
+				avr_raise_interrupt(avr, &p->ac);
+			}
+
+			avr_raise_irq(p->io.irq + ACOMP_IRQ_OUT, new_state);
+		}
+
+	}
+
+	return 0;
+}
+
+static inline void
+avr_schedule_sync_state(
+	struct avr_t * avr,
+	void *param)
+{
+	avr_cycle_timer_register(avr, 1, avr_acomp_sync_state, param);
+}
+
+static void
+avr_acomp_write_acsr(
+	struct avr_t * avr,
+	avr_io_addr_t addr,
+	uint8_t v,
+	void * param)
+{
+	avr_acomp_t * p = (avr_acomp_t *)param;
+
+	avr_core_watch_write(avr, addr, v);
+
+	if (avr_regbit_get(avr, p->acic) != (p->timer_irq ? 1:0)) {
+		if (p->timer_irq) {
+			avr_unconnect_irq(p->io.irq + ACOMP_IRQ_OUT, p->timer_irq);
+			p->timer_irq = NULL;
+		}
+		else {
+			avr_irq_t *irq = avr_io_getirq(avr, AVR_IOCTL_TIMER_GETIRQ(p->timer_name), TIMER_IRQ_IN_ICP);
+			if (irq) {
+				avr_connect_irq(p->io.irq + ACOMP_IRQ_OUT, irq);
+				p->timer_irq = irq;
+			}
+		}
+	}
+
+	avr_schedule_sync_state(avr, param);
+}
+
+static void
+avr_acomp_dependencies_changed(
+	struct avr_irq_t * irq,
+	uint32_t value,
+	void * param)
+{
+	avr_acomp_t * p = (avr_acomp_t *)param;
+	avr_schedule_sync_state(p->io.avr, param);
+}
+
+static void
+avr_acomp_irq_notify(
+	struct avr_irq_t * irq,
+	uint32_t value,
+	void * param)
+{
+	avr_acomp_t * p = (avr_acomp_t *)param;
+
+	switch (irq->irq) {
+		case ACOMP_IRQ_AIN0 ... ACOMP_IRQ_AIN1: {
+				p->ain_values[irq->irq - ACOMP_IRQ_AIN0] = value;
+				avr_schedule_sync_state(p->io.avr, param);
+			} 	break;
+		case ACOMP_IRQ_ADC0 ... ACOMP_IRQ_ADC15: {
+				p->adc_values[irq->irq - ACOMP_IRQ_ADC0] = value;
+				avr_schedule_sync_state(p->io.avr, param);
+			} 	break;
+	}
+}
+
+static void
+avr_acomp_register_dependencies(
+	avr_acomp_t *p,
+	avr_regbit_t rb)
+{
+	if (rb.reg) {
+		avr_irq_register_notify(
+					avr_iomem_getirq(p->io.avr, rb.reg, NULL, rb.bit),
+					avr_acomp_dependencies_changed,
+					p);
+	}
+}
+
+static void
+avr_acomp_reset(avr_io_t * port)
+{
+	avr_acomp_t * p = (avr_acomp_t *)port;
+
+	for (int i = 0; i < ACOMP_IRQ_COUNT; i++)
+		avr_irq_register_notify(p->io.irq + i, avr_acomp_irq_notify, p);
+
+	// register notification for changes of registers comparator does not own
+	// avr_register_io_write is tempting instead, but it requires that the handler
+	// updates the actual memory too. Given this is for the registers this module
+	// does not own, it is tricky to know whether it should write to the actual memory.
+	// E.g., if there is already a native handler for it then it will do the writing
+	// (possibly even omitting some bits etc). IInterefering would probably be wrong.
+	// On the  other hand if there isn't a handler already, then this hadnler would have to,
+	// as otherwise nobody will.
+	// This write notification mechanism should probably need reviewing and fixing
+	// For now using IRQ mechanism, as it is not intrusive
+
+	avr_acomp_register_dependencies(p, p->pradc);
+	avr_acomp_register_dependencies(p, p->aden);
+	avr_acomp_register_dependencies(p, p->acme);
+
+	// mux
+	for (int i = 0; i < ARRAY_SIZE(p->mux); ++i) {
+		avr_acomp_register_dependencies(p, p->mux[i]);
+	}
+}
+
+static const char * irq_names[ACOMP_IRQ_COUNT] = {
+	[ACOMP_IRQ_AIN0] = "16<ain0",
+	[ACOMP_IRQ_AIN1] = "16<ain1",
+	[ACOMP_IRQ_ADC0] = "16<adc0",
+	[ACOMP_IRQ_ADC1] = "16<adc1",
+	[ACOMP_IRQ_ADC2] = "16<adc2",
+	[ACOMP_IRQ_ADC3] = "16<adc3",
+	[ACOMP_IRQ_ADC4] = "16<adc4",
+	[ACOMP_IRQ_ADC5] = "16<adc5",
+	[ACOMP_IRQ_ADC6] = "16<adc6",
+	[ACOMP_IRQ_ADC7] = "16<adc7",
+	[ACOMP_IRQ_ADC8] = "16<adc0",
+	[ACOMP_IRQ_ADC9] = "16<adc9",
+	[ACOMP_IRQ_ADC10] = "16<adc10",
+	[ACOMP_IRQ_ADC11] = "16<adc11",
+	[ACOMP_IRQ_ADC12] = "16<adc12",
+	[ACOMP_IRQ_ADC13] = "16<adc13",
+	[ACOMP_IRQ_ADC14] = "16<adc14",
+	[ACOMP_IRQ_ADC15] = "16<adc15",
+	[ACOMP_IRQ_OUT] = ">out"
+};
+
+static avr_io_t _io = {
+	.kind = "ac",
+	.reset = avr_acomp_reset,
+	.irq_names = irq_names,
+};
+
+void
+avr_acomp_init(
+	avr_t * avr,
+	avr_acomp_t * p)
+{
+	p->io = _io;
+
+	avr_register_io(avr, &p->io);
+	avr_register_vector(avr, &p->ac);
+	// allocate this module's IRQ
+	avr_io_setirqs(&p->io, AVR_IOCTL_ACOMP_GETIRQ, ACOMP_IRQ_COUNT, NULL);
+
+	avr_register_io_write(avr, p->r_acsr, avr_acomp_write_acsr, p);
+}

--- a/simavr/sim/avr_acomp.h
+++ b/simavr/sim/avr_acomp.h
@@ -1,0 +1,89 @@
+/*
+	avr_acomp.h
+
+	Copyright 2017 Konstantin Begun
+
+ 	This file is part of simavr.
+
+	simavr is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	simavr is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with simavr.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __AVR_COMP_H___
+#define __AVR_COMP_H___
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "sim_avr.h"
+
+/*
+ * simavr Analog Comparator allows external code to feed real voltages to the
+ * simulator, and the simulator uses it's 'real' reference voltage
+ * to set comparator output accordingly and trigger in interrupt, if set up this way
+ *
+ */
+
+enum {
+	// input IRQ values. Values are /always/ volts * 1000 (millivolts)
+	ACOMP_IRQ_AIN0 = 0, ACOMP_IRQ_AIN1,
+	ACOMP_IRQ_ADC0, ACOMP_IRQ_ADC1, ACOMP_IRQ_ADC2, ACOMP_IRQ_ADC3,
+	ACOMP_IRQ_ADC4, ACOMP_IRQ_ADC5, ACOMP_IRQ_ADC6, ACOMP_IRQ_ADC7,
+	ACOMP_IRQ_ADC8, ACOMP_IRQ_ADC9, ACOMP_IRQ_ADC10, ACOMP_IRQ_ADC11,
+	ACOMP_IRQ_ADC12, ACOMP_IRQ_ADC13, ACOMP_IRQ_ADC14, ACOMP_IRQ_ADC15,
+	ACOMP_IRQ_OUT,		// output has changed
+	ACOMP_IRQ_COUNT
+};
+
+// Get the internal IRQ corresponding to the INT
+#define AVR_IOCTL_ACOMP_GETIRQ AVR_IOCTL_DEF('a','c','m','p')
+
+enum {
+	ACOMP_BANDGAP = 1100
+};
+
+typedef struct avr_acomp_t {
+	avr_io_t		io;
+
+	uint8_t			mux_inputs; // number of inputs (not mux bits!) in multiplexer. Other bits in mux below would be expected to be zero
+	avr_regbit_t	mux[4];
+	avr_regbit_t	pradc;		// ADC power reduction, this impacts on ability to use adc multiplexer
+	avr_regbit_t 	aden;		// ADC Enabled, this impacts on ability to use adc multiplexer
+	avr_regbit_t	acme;		// AC multiplexed input enabled
+
+	avr_io_addr_t	r_acsr;		// control & status register
+	avr_regbit_t	acis[2];	//
+	avr_regbit_t	acic;		// input capture enable
+	avr_regbit_t	aco;		// output
+	avr_regbit_t	acbg;		// bandgap select
+	avr_regbit_t	disabled;
+
+	char			timer_name;	// connected timer for incput capture triggering
+
+	// use ACI and ACIE bits
+	avr_int_vector_t ac;
+
+	// runtime data
+	uint16_t		adc_values[16];	// current values on the ADCs inputs
+	uint16_t		ain_values[2];  // current values on AIN inputs
+	avr_irq_t*		timer_irq;
+} avr_acomp_t;
+
+void avr_acomp_init(avr_t * avr, avr_acomp_t * port);
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif // __AVR_COMP_H___

--- a/simavr/sim/avr_timer.c
+++ b/simavr/sim/avr_timer.c
@@ -828,13 +828,16 @@ avr_timer_reset(
 			avr_connect_irq(&port->irq[TIMER_IRQ_OUT_COMP + compi], req.irq[0]);
 		}
 	}
+
+	avr_irq_register_notify(port->irq + TIMER_IRQ_IN_ICP, avr_timer_irq_icp, p);
+
 	avr_ioport_getirq_t req = {
 		.bit = p->icp
 	};
 	if (avr_ioctl(port->avr, AVR_IOCTL_IOPORT_GETIRQ_REGBIT, &req) > 0) {
 		// cool, got an IRQ for the input capture pin
 		//printf("%s-%c ICP Connecting PIN IRQ %d\n", __func__, p->name, req.irq[0]->irq);
-		avr_irq_register_notify(req.irq[0], avr_timer_irq_icp, p);
+		avr_connect_irq(req.irq[0], port->irq + TIMER_IRQ_IN_ICP);
 	}
 	p->ext_clock_flags &= ~(AVR_TIMER_EXTCLK_FLAG_STARTED | AVR_TIMER_EXTCLK_FLAG_TN |
 							AVR_TIMER_EXTCLK_FLAG_AS2 | AVR_TIMER_EXTCLK_FLAG_REVDIR);
@@ -844,6 +847,7 @@ avr_timer_reset(
 static const char * irq_names[TIMER_IRQ_COUNT] = {
 	[TIMER_IRQ_OUT_PWM0] = "8>pwm0",
 	[TIMER_IRQ_OUT_PWM1] = "8>pwm1",
+	[TIMER_IRQ_IN_ICP] = "<icp",
 	[TIMER_IRQ_OUT_COMP + 0] = ">compa",
 	[TIMER_IRQ_OUT_COMP + 1] = ">compb",
 	[TIMER_IRQ_OUT_COMP + 2] = ">compc",

--- a/simavr/sim/avr_timer.h
+++ b/simavr/sim/avr_timer.h
@@ -39,6 +39,7 @@ enum {
 enum {
 	TIMER_IRQ_OUT_PWM0 = 0,
 	TIMER_IRQ_OUT_PWM1,
+	TIMER_IRQ_IN_ICP,	// input capture
 	TIMER_IRQ_OUT_COMP,	// comparator pins output IRQ
 
 	TIMER_IRQ_COUNT = TIMER_IRQ_OUT_COMP + AVR_TIMER_COMP_COUNT

--- a/tests/atmega88_ac_test.c
+++ b/tests/atmega88_ac_test.c
@@ -1,0 +1,179 @@
+/*
+	atmega88_ac_test.c
+
+	Copyright 2017 Konstantin Begun
+
+ 	This file is part of simavr.
+
+	simavr is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	simavr is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with simavr.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <avr/io.h>
+#include <stdio.h>
+#include <avr/interrupt.h>
+#include <avr/sleep.h>
+#include <util/delay.h>
+#include <avr/cpufunc.h>
+
+/*
+ * This demonstrate how to use the avr_mcu_section.h file
+ * The macro adds a section to the ELF file with useful
+ * information for the simulator
+ */
+#include "avr_mcu_section.h"
+AVR_MCU(F_CPU, "atmega88");
+
+static int uart_putchar(char c, FILE *stream) {
+  if (c == '\n')
+    uart_putchar('\r', stream);
+  loop_until_bit_is_set(UCSR0A, UDRE0);
+  UDR0 = c;
+  return 0;
+}
+
+static FILE mystdout = FDEV_SETUP_STREAM(uart_putchar, NULL,
+                                         _FDEV_SETUP_WRITE);
+
+volatile uint8_t int_done;
+
+ISR(ANALOG_COMP_vect)
+{
+	int_done = 1;
+}
+
+ISR(TIMER1_CAPT_vect)
+{
+	int_done = 2;
+}
+
+static inline void output_value() {
+	putchar(ACSR & _BV(ACO) ? '1':'0');
+}
+
+static inline void output_test(uint8_t expected) {
+	putchar(int_done == expected ? 'Y':'N');
+}
+
+int main(void)
+{
+	stdout = &mystdout;
+
+	sei();
+
+	ACSR = 0;
+
+	printf("Check analog comparator with polling values\n");
+
+	// check all the inputs
+	for(uint8_t t = 0; t < 2; ++t) {		// run twice, first with AIN0, second with bandgap
+		ADCSRB = 0;		// multiplexer off
+		_NOP();	// for sync delay
+		output_value();
+		// now with multiplexer
+		ADCSRB = _BV(ACME);
+		_NOP();
+		for(uint8_t i = 0; i < 8;++i)
+		{
+			// this is relying that all 3 mux bits are next to each other, which is the case for atmega88
+			output_value();
+			ADMUX += _BV(MUX0);
+			_NOP();
+		}
+		// switch to bandgap
+		ACSR |= _BV(ACBG);
+		_NOP();
+	}
+
+	putchar('\n');
+
+	// check interrupts
+	printf("Check analog comparator interrupts\n");
+	// in this test bandgap is expected to be above ADC0 and below ADC1
+
+	ADCSRB = _BV(ACME);
+	ADMUX = 0;	// ADC0
+	ACSR = _BV(ACBG) | _BV(ACIE) | _BV(ACI);		// enable interrupts on output triggering
+
+	// switch to ADC1
+	int_done = 0;
+	ADMUX = _BV(MUX0);
+	_delay_us(500);
+	output_test(1);
+
+	// back to ADC0
+	int_done = 0;
+	ADMUX = 0;
+	_delay_us(500);
+	output_test(1);
+
+	// change to trigger on falling edge
+	ACSR = _BV(ACBG) | _BV(ACIE) | _BV(ACI) | _BV(ACIS1);
+
+	// switch to ADC1 (falling edge)
+	int_done = 0;
+	ADMUX = _BV(MUX0);
+	_delay_us(500);
+	output_test(1);
+
+	// switch to ADC0 (rising edge)
+	int_done = 0;
+	ADMUX = 0;
+	_delay_us(500);
+	output_test(0);		// expect no interrupt
+
+	// change to trigger on rising edge
+	ACSR = _BV(ACBG) | _BV(ACIE) | _BV(ACI) | _BV(ACIS1) | _BV(ACIS0);
+
+	// switch to ADC1 (falling edge)
+	int_done = 0;
+	ADMUX = _BV(MUX0);
+	_delay_us(500);
+	output_test(0);	// expect no interrupt
+
+	// switch to ADC0 (rising edge)
+	int_done = 0;
+	ADMUX = 0;
+	_delay_us(500);
+	output_test(1);
+
+	putchar('\n');
+
+	// now check timer1 input capture
+	printf("Check analog comparator triggering timer capture\n");
+	// setup AC for rising edge, disable comparator own interrupt and enable timer1 capture
+	ACSR = _BV(ACBG) | _BV(ACIC) | _BV(ACIS1) | _BV(ACIS0);
+
+	// now set up timer to capture on rising edge
+	TCCR1A = 0;
+	TCNT1 = 5555;
+	TIMSK1 = _BV(ICIE1);		// enable capture interrupt
+	TCCR1B = _BV(ICES1) | _BV(CS10);
+
+	// switch to ADC1 (falling edge)
+	int_done = 0;
+	ADMUX = _BV(MUX0);
+	_delay_us(500);
+	output_test(0);	// expect no interrupt
+
+	// switch to ADC0 (rising edge)
+	int_done = 0;
+	ADMUX = 0;
+	_delay_us(500);
+	output_test(2);
+
+	cli();
+	sleep_cpu();
+
+}
+

--- a/tests/test_atmega88_ac_test.c
+++ b/tests/test_atmega88_ac_test.c
@@ -1,0 +1,34 @@
+#include "tests.h"
+#include "avr_acomp.h"
+
+int main(int argc, char **argv) {
+	tests_init(argc, argv);
+
+	static const char *expected =
+		"Check analog comparator with polling values\r\n"
+		"110110101010000100\r\n"
+		"Check analog comparator interrupts\r\n"
+		"YYYYYY\r\n"
+		"Check analog comparator triggering timer capture\r\n"
+		"YY";
+
+	avr_t *avr = tests_init_avr("atmega88_ac_test.axf");
+
+	// set voltages
+	avr_raise_irq(avr_io_getirq(avr, AVR_IOCTL_ACOMP_GETIRQ, ACOMP_IRQ_AIN0), 2000);
+	avr_raise_irq(avr_io_getirq(avr, AVR_IOCTL_ACOMP_GETIRQ, ACOMP_IRQ_AIN1), 1800);
+	avr_raise_irq(avr_io_getirq(avr, AVR_IOCTL_ACOMP_GETIRQ, ACOMP_IRQ_ADC0), 200);
+	avr_raise_irq(avr_io_getirq(avr, AVR_IOCTL_ACOMP_GETIRQ, ACOMP_IRQ_ADC1), 3000);
+	avr_raise_irq(avr_io_getirq(avr, AVR_IOCTL_ACOMP_GETIRQ, ACOMP_IRQ_ADC2), 1500);
+	avr_raise_irq(avr_io_getirq(avr, AVR_IOCTL_ACOMP_GETIRQ, ACOMP_IRQ_ADC3), 1500);
+	avr_raise_irq(avr_io_getirq(avr, AVR_IOCTL_ACOMP_GETIRQ, ACOMP_IRQ_ADC4), 3000);
+	avr_raise_irq(avr_io_getirq(avr, AVR_IOCTL_ACOMP_GETIRQ, ACOMP_IRQ_ADC5), 200);
+	avr_raise_irq(avr_io_getirq(avr, AVR_IOCTL_ACOMP_GETIRQ, ACOMP_IRQ_ADC6), 3000);
+	avr_raise_irq(avr_io_getirq(avr, AVR_IOCTL_ACOMP_GETIRQ, ACOMP_IRQ_ADC7), 1500);
+
+	tests_assert_uart_receive_avr(avr, 100000,
+				   expected, '0');
+
+	tests_success();
+	return 0;
+}


### PR DESCRIPTION
I have added implementation of the analog comparator for all parts, apart from megaxm1 family, as it is completely different there.
It supports all the features including triggering input capture on a timer. For this I had to make a small change in the timer implementation to have a separate input capture irq that is connected to the relevant port pin irq, instead of just registering notifications from the port. This allows triggering of the capture independently from the port.
Comprehensive tests added too.