### PR TITLE
misc: Strip off tag prefix from the pkg-config version

### DIFF
--- a/simavr/Makefile
+++ b/simavr/Makefile
@@ -18,8 +18,7 @@
 
 SHELL 			:= ${shell which bash}
 SIMAVR_VERSION	:= ${shell \
-	{ git log -1 --tags --simplify-by-decoration --pretty="format:%d"|\
-		sed -e 's/[\(\) ]//g'; } || \
+	git describe --abbrev=0 --tags || \
 	echo "unknown" }
 SIMAVR_REVISION	= 2
 


### PR DESCRIPTION
For example, before this change the version would
be set as 'tag:v1.5'. After this change it will be
'v1.5'.