### PR TITLE
parts: Build a simavr virtual parts library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ RELEASE	?= 0
 
 .PHONY: doc
 
-all:	build-simavr build-tests build-examples
+all:	build-simavr build-tests build-examples build-parts
 
 build-simavr:
 	$(MAKE) -C simavr RELEASE=$(RELEASE)
@@ -19,6 +19,9 @@ build-tests: build-simavr
 
 build-examples: build-simavr
 	$(MAKE) -C examples RELEASE=$(RELEASE)
+
+build-parts: build-simavr
+	$(MAKE) -C examples/parts RELEASE=$(RELEASE)
 
 install:
 	$(MAKE) -C simavr install RELEASE=$(RELEASE)
@@ -33,5 +36,6 @@ clean:
 	$(MAKE) -C simavr clean
 	$(MAKE) -C tests clean
 	$(MAKE) -C examples clean
+	$(MAKE) -C examples/parts clean
 	$(MAKE) -C doc clean
 

--- a/examples/parts/Makefile
+++ b/examples/parts/Makefile
@@ -1,0 +1,62 @@
+#	Copyright 2014,2017 Doug Szumski <d.s.szumski@gmail.com>
+#	Copyright 2008-2011 Michel Pollet <buserror@gmail.com>
+#
+#	This file is part of simavr.
+#
+#	simavr is free software: you can redistribute it and/or modify
+#	it under the terms of the GNU General Public License as published by
+#	the Free Software Foundation, either version 3 of the License, or
+#	(at your option) any later version.
+#
+#	simavr is distributed in the hope that it will be useful,
+#	but WITHOUT ANY WARRANTY; without even the implied warranty of
+#	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#	GNU General Public License for more details.
+#
+#	You should have received a copy of the GNU General Public License
+#	along with simavr.  If not, see <http://www.gnu.org/licenses/>.
+
+LDFLAGS += -lpthread
+simavr = ../../
+IPATH += ${simavr}/simavr/sim
+
+target := libsimavrparts
+
+all: obj ${target}
+
+include ${simavr}/Makefile.common
+
+objects := $(patsubst %.c,${OBJ}/%.o, $(wildcard *.c))
+
+# Unless the VHCI_USB env var is set, don't build this because it requires
+# a supporting library to be installed. See examples/extra_board_usb/README
+# for details on how to build it.
+ifndef VHCI_USB
+	objects := $(filter-out %vhci_usb.o, $(objects))
+endif
+
+#
+# Static library
+#
+static_lib = $(target).a
+
+${OBJ}/${static_lib} : ${objects}
+${OBJ}/${static_lib} :
+	$(AR) cru $@ $^
+${target}: ${OBJ}/${static_lib}
+
+#
+# Shared library (Linux only)
+#
+shared_lib = ${target}.so.1
+
+${OBJ}/${shared_lib} : ${objects}
+${OBJ}/${shared_lib} :
+	${CC} -shared -Wl,-soname,${shared_lib} $^ -o $@
+ifeq (${shell uname}, Linux)
+${target}: ${OBJ}/${shared_lib}
+endif
+	@echo $@ done
+
+clean: clean-${OBJ}
+	rm -rf *.hex *.a *.axf *.vcd .*.swo .*.swp .*.swm .*.swn *.so *.o

--- a/simavr/Makefile
+++ b/simavr/Makefile
@@ -94,19 +94,26 @@ PREFIX = ${DESTDIR}
 
 install : all
 	$(MKDIR) $(DESTDIR)/include/simavr/avr
+	$(MKDIR) $(DESTDIR)/include/simavr/parts
 	$(INSTALL) -m644 sim/*.h $(DESTDIR)/include/simavr/
 	$(INSTALL) -m644 sim_core_*.h $(DESTDIR)/include/simavr/
 	$(INSTALL) -m644 sim/avr/*.h $(DESTDIR)/include/simavr/avr/
+	$(INSTALL) -m644 ../examples/parts/*.h $(DESTDIR)/include/simavr/parts/
 	$(MKDIR) $(DESTDIR)/lib
 	$(INSTALL) ${OBJ}/libsimavr.a $(DESTDIR)/lib/
+	$(INSTALL) ../examples/parts/${OBJ}/libsimavrparts.a $(DESTDIR)/lib/
 	$(MKDIR) $(DESTDIR)/lib/pkgconfig/
 	sed -e "s|PREFIX|${PREFIX}|g" -e "s|VERSION|${SIMAVR_VERSION}|g" \
 		simavr-avr.pc >$(DESTDIR)/lib/pkgconfig/simavr-avr.pc
 	sed -e "s|PREFIX|${PREFIX}|g" -e "s|VERSION|${SIMAVR_VERSION}|g" \
 		simavr.pc >$(DESTDIR)/lib/pkgconfig/simavr.pc
+	sed -e "s|PREFIX|${PREFIX}|g" -e "s|VERSION|${SIMAVR_VERSION}|g" \
+		simavrparts.pc >$(DESTDIR)/lib/pkgconfig/simavrparts.pc
 ifeq (${shell uname}, Linux)
 	$(INSTALL) ${OBJ}/libsimavr.so.1 $(DESTDIR)/lib/
+	$(INSTALL) ../examples/parts/${OBJ}/libsimavrparts.so.1 $(DESTDIR)/lib/
 	ln -sf libsimavr.so.1 $(DESTDIR)/lib/libsimavr.so
+	ln -sf libsimavrparts.so.1 $(DESTDIR)/lib/libsimavrparts.so
 endif
 	$(MKDIR) $(DESTDIR)/bin
 	$(INSTALL) ${OBJ}/${target}.elf $(DESTDIR)/bin/simavr

--- a/simavr/simavrparts.pc
+++ b/simavr/simavrparts.pc
@@ -1,0 +1,10 @@
+prefix=PREFIX
+exec_prefix=${prefix}
+includedir=${prefix}/include/
+libdir=${exec_prefix}/lib
+
+Name: simavr
+Description: Virtual parts library for simavr
+Version: VERSION
+Cflags: -I${includedir}/simavr/parts
+Libs: -L${libdir} -lsimavrparts -lsimavr


### PR DESCRIPTION
An external project using simavr can link against libsimavr.
However, there is no support for using virtual parts from the
examples folder in the external project.

This commit adds support for building a parts library, which the
external project can link against. Presently this library is fairly
small, but as the number of parts grows this approach may need
to be changed. A longer term solution could be to provide an API as
part of the simavr library which can manage the parts. Simavr could
dynamically load and provide parts as required by the external
project.

Like libsimavr, this patch makes no attempt to make the version easy
to set. That can be covered under a different PR.