### PR TITLE
Add missing header file to 'sim_hex.h'

### DIFF
--- a/simavr/sim/sim_hex.h
+++ b/simavr/sim/sim_hex.h
@@ -24,6 +24,7 @@
 #define __SIM_HEX_H___
 
 #include <stdint.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
'size_t' is not defined in any of the header files included in
'sim_hex.h', even though it is used in there.

Without this, you cannot parse `sim_hex.h` on its own.

You can see a list of all headers that define 'size_t' here
http://en.cppreference.com/w/c/types/size_t