### PR TITLE
A couple of alterations to make it work on OS X

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -48,7 +48,7 @@ CORE_CFLAGS	= -DAVR_CORE=1
 ifeq (${shell uname}, Darwin)
  # gcc 4.2 from MacOS is really not up to scratch anymore
  CC			= clang
- AVR_ROOT 	:= "/Applications/Arduino.app/Contents/Resources/Java/hardware/tools/avr/"
+ AVR_ROOT 	:= "/Applications/Arduino.app/Contents/Java/hardware/tools/avr/"
  AVR 		:= ${AVR_ROOT}/bin/avr-
  # Thats for MacPorts libelf
  ifeq (${shell test -d /opt/local && echo Exists}, Exists)


### PR DESCRIPTION
Installation via homebrew does not work at all (some odd failure that I don't really understand), so I downloaded the source. I had to make a couple of alterations to the makefile to get it to work.

-Werror causes the compilation to fail because of warnings about deprecated functions in the Mac's GLUT OpenGL libraries. As these problems are not that important I just removed it and it seems to work fine. However, I'm sure it's there for a reason...

The other change was that the path to the AVR libraries within the Arduino IDE bundle was not correct (perhaps it has changed over time?) so none of the cores worked for me. With these 2 changes it all compiled and seems to work.