### PR TITLE
Make parallel builds succeed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ build-tests: build-simavr
 build-examples: build-simavr
 	$(MAKE) -C examples RELEASE=$(RELEASE)
 
-build-parts: build-simavr
+build-parts: build-examples
 	$(MAKE) -C examples/parts RELEASE=$(RELEASE)
 
 install:


### PR DESCRIPTION
Currently parallel builds fail every time for me (output provided). This seems to be related to the examples and parts stomping over each other.

```
CC charlcd.c
error: unable to open output file 'obj-x86_64-apple-darwin16.7.0/charlcd.o': 'No such file or directory'
1 error generated.
make[2]: *** [obj-x86_64-apple-darwin16.7.0/charlcd.o] Error 1
make[2]: *** Waiting for unfinished jobs....
   2122      14       5    2141     85d atmega48_charlcd.axf
AVR-CC atmega1280_i2ctest.c
CC i2ctest.c
error: unable to open output file 'obj-x86_64-apple-darwin16.7.0/i2ctest.o': 'No such file or directory'
1 error generated.
make[2]: *** [obj-x86_64-apple-darwin16.7.0/i2ctest.o] Error 1
make[2]: *** Waiting for unfinished jobs....
   1208      16      12    1236     4d4 atmega1280_i2ctest.axf
AVR-CC atmega48_ledramp.c
CC ledramp.c
error: unable to open output file 'obj-x86_64-apple-darwin16.7.0/ledramp.o': 'No such file or directory'
1 error generated.
make[2]: *** [obj-x86_64-apple-darwin16.7.0/ledramp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
   1910      32      11    1953     7a1 atmega48_ledramp.axf
AVR-CC atmega328p_dummy_blinky.c
CC simduino.c
error: unable to open output file 'obj-x86_64-apple-darwin16.7.0/simduino.o': 'No such file or directory'
1 error generated.
make[2]: *** [obj-x86_64-apple-darwin16.7.0/simduino.o] Error 1
make[2]: *** Waiting for unfinished jobs....
    382      66       6     454     1c6 atmega328p_dummy_blinky.axf
rm atmega328p_dummy_blinky.axf
AVR-CC atmega32_ssd1306.c
CC ssd1306demo.c
error: unable to open output file 'obj-x86_64-apple-darwin16.7.0/ssd1306demo.o': 'No such file or directory'
1 error generated.
make[2]: *** [obj-x86_64-apple-darwin16.7.0/ssd1306demo.o] Error 1
```