### PR TITLE
Added a define "FALLTHROUGH" to suppress 'this statement may fallthrogh' messages

### DIFF
--- a/examples/board_timer_64led/timer_64led.c
+++ b/examples/board_timer_64led/timer_64led.c
@@ -104,8 +104,10 @@ void displayCB(void)		/* function called whenever redisplay needed */
 			switch (i) {
 				case 3:
 					dy += 3.0f * pixsize;
+					FALLTHROUGH
 				case 6:
 					dy += 3.0f * pixsize;
+					FALLTHROUGH
 				case 0:
 					dx += 1.0f * pixsize;
 					glVertex2f(dx + size, dy + size); glVertex2f(dx, dy + size); glVertex2f(dx, dy); glVertex2f(dx + size, dy);

--- a/simavr/sim/avr_adc.c
+++ b/simavr/sim/avr_adc.c
@@ -140,8 +140,10 @@ avr_adc_read_h(
 	switch (p->read_status) {
 		case 0:
 			avr_adc_read_l(avr, p->r_adcl, param);
+			FALLTHROUGH
 		case 1:
 			p->read_status = 2;
+			FALLTHROUGH
 		default:
 			return avr_core_watch_read(avr, addr);
 	}

--- a/simavr/sim/sim_avr.h
+++ b/simavr/sim/sim_avr.h
@@ -26,6 +26,16 @@
 extern "C" {
 #endif
 
+#ifndef __has_attribute
+	#define __has_attribute(x) 0
+#endif
+
+#if __has_attribute(fallthrough)
+	#define FALLTHROUGH __attribute__((fallthrough));
+#else
+	#define FALLTHROUGH
+#endif
+
 #include "sim_irq.h"
 #include "sim_interrupts.h"
 #include "sim_cmds.h"

--- a/simavr/sim/sim_core.c
+++ b/simavr/sim/sim_core.c
@@ -976,6 +976,7 @@ run_one_again:
 				case 0x9518: 	// RETI -- Return from Interrupt -- 1001 0101 0001 1000
 					avr_sreg_set(avr, S_I, 1);
 					avr_interrupt_reti(avr);
+					FALLTHROUGH
 				case 0x9508: {	// RET -- Return -- 1001 0101 0000 1000
 					new_pc = _avr_pop_addr(avr);
 					cycle += 1 + avr->address_size;


### PR DESCRIPTION
Since avr-gcc version 7 the flag -Wimplicit-fallthrough is set, so that a missing "break;" inside a switch-case statement will throw an error in the compiling process.
The missing breaks are now replaced by the FALLTHROUGH define and no errors occours.
The FALLTHROUGH is simply an "__attribute__((fallthrough));" - if it is supported by the compiler (defined in sim_avr.h).

The commit 88b50bb (removing -Werror) didn't fixed the issue #239.
The define FALLTHROUGH is tested with avr-gcc 7.1.0 and 4.4.5.