### PR TITLE
ssd1306 improvements to support V/H flipped display layouts and addressing modes other than paged

### DIFF
--- a/examples/parts/ssd1306_glut.c
+++ b/examples/parts/ssd1306_glut.c
@@ -24,6 +24,7 @@
  */
 
 #include <stdlib.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 #include "ssd1306_glut.h"
@@ -33,6 +34,8 @@
 #else
 #include <GL/glut.h>
 #endif
+
+static bool disp_flip_v, disp_flip_h;
 
 ssd1306_colour_t oled_colour_g;
 float pix_size_g = 1.0;
@@ -46,8 +49,10 @@ float ssd1306_colours[][3] =
 };
 
 void
-ssd1306_gl_init (float pix_size, ssd1306_colour_t oled_colour)
+ssd1306_gl_init (float pix_size, ssd1306_colour_t oled_colour, bool flip_v, bool flip_h)
 {
+	disp_flip_v = flip_v;
+	disp_flip_h = flip_h;
 	pix_size_g = pix_size;
 	oled_colour_g = oled_colour;
 }
@@ -112,10 +117,10 @@ ssd1306_gl_put_pixel_column (uint8_t block_pixel_column, float pixel_opacity,
 static uint8_t
 ssd1306_gl_get_vram_byte (ssd1306_t *part, uint8_t page, uint8_t column)
 {
-	uint8_t seg_remap_default = ssd1306_get_flag (
-	                part, SSD1306_FLAG_SEGMENT_REMAP_0);
-	uint8_t seg_comscan_default = ssd1306_get_flag (
-	                part, SSD1306_FLAG_COM_SCAN_NORMAL);
+	uint8_t seg_remap_default = !!ssd1306_get_flag (
+	                part, SSD1306_FLAG_SEGMENT_REMAP_0) ^ !!disp_flip_h;
+	uint8_t seg_comscan_default = !!ssd1306_get_flag (
+	                part, SSD1306_FLAG_COM_SCAN_NORMAL) ^ !!disp_flip_v;
 
 	if (seg_remap_default && seg_comscan_default)
 	{

--- a/examples/parts/ssd1306_glut.h
+++ b/examples/parts/ssd1306_glut.h
@@ -34,6 +34,6 @@ void
 ssd1306_gl_draw (ssd1306_t *part);
 
 void
-ssd1306_gl_init (float pix_size, ssd1306_colour_t oled_colour);
+ssd1306_gl_init (float pix_size, ssd1306_colour_t oled_colour, bool flip_v, bool flip_h);
 
 #endif

--- a/examples/parts/ssd1306_virt.c
+++ b/examples/parts/ssd1306_virt.c
@@ -100,18 +100,25 @@ ssd1306_update_command_register (ssd1306_t *part)
 		case SSD1306_VIRT_SET_COLUMN_LOW_NIBBLE
 		                ... SSD1306_VIRT_SET_COLUMN_LOW_NIBBLE + 0xF:
 			part->spi_data -= SSD1306_VIRT_SET_COLUMN_LOW_NIBBLE;
-			part->cursor.column = (part->cursor.column & 0xF0)
+			if (part->mem_addr_mode == 0x02) {
+				part->cursor.column = (part->cursor.column & 0xF0)
 			                | (part->spi_data & 0xF);
+			}
 			//printf ("SSD1306: SET COLUMN LOW NIBBLE: 0x%02x\n",part->spi_data);
 			SSD1306_CLEAR_COMMAND_REG(part);
 			return;
 		case SSD1306_VIRT_SET_COLUMN_HIGH_NIBBLE
 		                ... SSD1306_VIRT_SET_COLUMN_HIGH_NIBBLE + 0xF:
 			part->spi_data -= SSD1306_VIRT_SET_COLUMN_HIGH_NIBBLE;
-			part->cursor.column = (part->cursor.column & 0xF)
+			if (part->mem_addr_mode == 0x02) {
+				part->cursor.column = (part->cursor.column & 0xF)
 			                | ((part->spi_data & 0xF) << 4);
+			}
 			//printf ("SSD1306: SET COLUMN HIGH NIBBLE: 0x%02x\n", part->spi_data);
 			SSD1306_CLEAR_COMMAND_REG(part);
+			return;
+		case SSD1306_VIRT_MEM_ADDRESSING:
+			part->command_register = part->spi_data;
 			return;
 		case SSD1306_VIRT_SET_SEG_REMAP_0:
 			ssd1306_set_flag (part, SSD1306_FLAG_SEGMENT_REMAP_0,
@@ -156,6 +163,10 @@ ssd1306_update_setting (ssd1306_t *part)
 			ssd1306_set_flag (part, SSD1306_FLAG_DIRTY, 1);
 			SSD1306_CLEAR_COMMAND_REG(part);
 			//printf ("SSD1306: CONTRAST SET: 0x%02x\n", part->contrast_register);
+			return;
+		case SSD1306_VIRT_MEM_ADDRESSING:
+			part->mem_addr_mode = part->spi_data & 0x03;
+			SSD1306_CLEAR_COMMAND_REG(part);
 			return;
 		default:
 			// Unknown command

--- a/examples/parts/ssd1306_virt.h
+++ b/examples/parts/ssd1306_virt.h
@@ -138,6 +138,7 @@ typedef struct ssd1306_t
 	avr_irq_t * irq;
 	struct avr_t * avr;
 	uint8_t columns, rows, pages;
+	uint8_t mem_addr_mode;
 	struct ssd1306_virt_cursor_t cursor;
 	uint8_t vram[SSD1306_VIRT_PAGES][SSD1306_VIRT_COLUMNS];
 	uint16_t flags;


### PR DESCRIPTION
_Arduboy_ uses horizontal addressing mode and the display is flipped both vertically and horizontally.