### PR TITLE
use only 12 bits for ubrr

### DIFF
--- a/simavr/cores/sim_megaxm1.h
+++ b/simavr/cores/sim_megaxm1.h
@@ -137,8 +137,7 @@ const struct mcu_t SIM_CORENAME = {
 			.r_ucsra = 0,
 			.r_ucsrb = 0,
 			.r_ucsrc = 0,
-			.r_ubrrl = 0,
-			.r_ubrrh = 0,
+
 
 			.rxc = {
 				.enable = AVR_IO_REGBIT(LINENIR, LENRXOK),

--- a/simavr/sim/avr_uart.c
+++ b/simavr/sim/avr_uart.c
@@ -222,7 +222,7 @@ avr_uart_baud_write(
 {
 	avr_uart_t * p = (avr_uart_t *)param;
 	avr_core_watch_write(avr, addr, v);
-	uint32_t val = avr->data[p->r_ubrrl] | ((avr->data[p->r_ubrrh]&0x0F) << 8);
+	uint32_t val = avr_regbit_get(avr,p->ubrrl) | (avr_regbit_get(avr,p->ubrrh) << 8);
 
 	const int databits[] = { 5,6,7,8,  /* 'reserved', assume 8 */8,8,8, 9 };
 	int db = databits[avr_regbit_get(avr, p->ucsz) | (avr_regbit_get(avr, p->ucsz2) << 2)];

--- a/simavr/sim/avr_uart.c
+++ b/simavr/sim/avr_uart.c
@@ -222,7 +222,7 @@ avr_uart_baud_write(
 {
 	avr_uart_t * p = (avr_uart_t *)param;
 	avr_core_watch_write(avr, addr, v);
-	uint32_t val = avr->data[p->r_ubrrl] | (avr->data[p->r_ubrrh] << 8);
+	uint32_t val = avr->data[p->r_ubrrl] | ((avr->data[p->r_ubrrh]&0x0F) << 8);
 
 	const int databits[] = { 5,6,7,8,  /* 'reserved', assume 8 */8,8,8, 9 };
 	int db = databits[avr_regbit_get(avr, p->ucsz) | (avr_regbit_get(avr, p->ucsz2) << 2)];

--- a/simavr/sim/avr_uart.c
+++ b/simavr/sim/avr_uart.c
@@ -526,8 +526,8 @@ avr_uart_init(
 		avr_register_io_write(avr, p->udrc.enable.reg, avr_uart_write, p);
 	if (p->r_ucsra)
 		avr_register_io_write(avr, p->r_ucsra, avr_uart_write, p);
-	if (p->r_ubrrl)
-		avr_register_io_write(avr, p->r_ubrrl, avr_uart_baud_write, p);
+	if (p->ubrrl.reg)
+		avr_register_io_write(avr, p->ubrrl.reg, avr_uart_baud_write, p);
 	avr_register_io_write(avr, p->rxen.reg, avr_uart_write, p);
 }
 

--- a/simavr/sim/avr_uart.h
+++ b/simavr/sim/avr_uart.h
@@ -107,8 +107,6 @@ typedef struct avr_uart_t {
 	avr_regbit_t	upe;		// parity error bit
 	avr_regbit_t	rxb8;		// receive data bit 8
 
-	avr_io_addr_t r_ubrrl,r_ubrrh;
-
 	avr_regbit_t	ubrrl;
 	avr_regbit_t	ubrrh;
 
@@ -157,8 +155,7 @@ void avr_uart_init(avr_t * avr, avr_uart_t * port);
 		.r_ucsra = UCSR ## _name ## A, \
 		.r_ucsrb = UCSR ## _name ## B, \
 		.r_ucsrc = UCSR ## _name ## C, \
-		.r_ubrrl = UBRR ## _name ## L, \
-		.r_ubrrh = UBRR ## _name ## H, \
+	\
 		.rxc = { \
 			.enable = AVR_IO_REGBIT(UCSR ## _name ## B, RXCIE ## _name), \
 			.raised = AVR_IO_REGBIT(UCSR ## _name ## A, RXC ## _name), \
@@ -201,8 +198,7 @@ void avr_uart_init(avr_t * avr, avr_uart_t * port);
 		.r_ucsra = UCSR ## _rname_ix ## A, \
 		.r_ucsrb = UCSR ## _rname_ix ## B, \
 		.r_ucsrc = UCSR ## _rname_ix ## C, \
-		.r_ubrrl = UBRR ## _rname_ix ## L, \
-		.r_ubrrh = UBRR ## _rname_ix ## H, \
+	\
 		.rxc = { \
 			.enable = AVR_IO_REGBIT(UCSR ## _rname_ix ## B, RXCIE ## _rname_ix), \
 			.raised = AVR_IO_REGBIT(UCSR ## _rname_ix ## A, RXC ## _rname_ix), \

--- a/simavr/sim/avr_uart.h
+++ b/simavr/sim/avr_uart.h
@@ -109,6 +109,9 @@ typedef struct avr_uart_t {
 
 	avr_io_addr_t r_ubrrl,r_ubrrh;
 
+	avr_regbit_t	ubrrl;
+	avr_regbit_t	ubrrh;
+
 	avr_int_vector_t rxc;
 	avr_int_vector_t txc;
 	avr_int_vector_t udrc;	
@@ -148,7 +151,9 @@ void avr_uart_init(avr_t * avr, avr_uart_t * port);
 		.usbs = AVR_IO_REGBIT(UCSR ## _name ## C, USBS ## _name), \
 		.ucsz = AVR_IO_REGBITS(UCSR ## _name ## C, UCSZ ## _name ## 0, 0x3), \
 		.ucsz2 = AVR_IO_REGBIT(UCSR ## _name ## B, UCSZ ## _name ## 2), \
-	\
+		.ubrrl = AVR_IO_REGBITS(UBRR ## _name ## L, 0,0xFF), \
+		.ubrrh = AVR_IO_REGBITS(UBRR ## _name ## H, 0,0xF), \
+		\
 		.r_ucsra = UCSR ## _name ## A, \
 		.r_ucsrb = UCSR ## _name ## B, \
 		.r_ucsrc = UCSR ## _name ## C, \
@@ -190,6 +195,8 @@ void avr_uart_init(avr_t * avr, avr_uart_t * port);
 		.usbs = AVR_IO_REGBIT(UCSR ## _rname_ix ## C, USBS ## _rname_ix), \
 		.ucsz = AVR_IO_REGBITS(UCSR ## _rname_ix ## C, UCSZ ## _rname_ix ## 0, 0x3), \
 		.ucsz2 = AVR_IO_REGBIT(UCSR ## _rname_ix ## B, UCSZ ## _rname_ix ## 2), \
+		.ubrrl = AVR_IO_REGBITS(UBRR ## _rname_ix ## L, 0,0xFF), \
+		.ubrrh = AVR_IO_REGBITS(UBRR ## _rname_ix ## H, 0,0xF), \
 	\
 		.r_ucsra = UCSR ## _rname_ix ## A, \
 		.r_ucsrb = UCSR ## _rname_ix ## B, \


### PR DESCRIPTION
I'm unsure if it's applicable on every AVR type