### PR TITLE
Make sure sim_core_declare.h is included *after* avr includes

### DIFF
--- a/simavr/cores/sim_core_declare.h
+++ b/simavr/cores/sim_core_declare.h
@@ -71,10 +71,10 @@
 # define _FUSE_HELPER { 0 }
 #endif
 
-#ifdef MCUSR
-# define MCU_STATUS_REG MCUSR
-#else
+#ifdef MCUCSR
 # define MCU_STATUS_REG MCUCSR
+#else
+# define MCU_STATUS_REG MCUSR
 #endif
 
 #ifdef SIGNATURE_0

--- a/simavr/cores/sim_mega128.c
+++ b/simavr/cores/sim_mega128.c
@@ -20,7 +20,6 @@
  */
 
 #include "sim_avr.h"
-#include "sim_core_declare.h"
 #include "avr_eeprom.h"
 #include "avr_flash.h"
 #include "avr_watchdog.h"
@@ -39,6 +38,8 @@ void m128_reset(struct avr_t * avr);
 #define _AVR_IO_H_
 #define __ASSEMBLER__
 #include "avr/iom128.h"
+
+#include "sim_core_declare.h"
 
 /*
  * This is a template for all of the 128 devices, hopefully

--- a/simavr/cores/sim_mega1280.c
+++ b/simavr/cores/sim_mega1280.c
@@ -20,7 +20,6 @@
  */
 
 #include "sim_avr.h"
-#include "sim_core_declare.h"
 #include "avr_eeprom.h"
 #include "avr_flash.h"
 #include "avr_watchdog.h"
@@ -42,6 +41,8 @@ void m1280_reset(struct avr_t * avr);
 #define __AVR_ATmega1280__
 #endif
 #include "avr/iom1280.h"
+
+#include "sim_core_declare.h"
 
 /*
  * This is a template for all of the 1280 devices, hopefully

--- a/simavr/cores/sim_mega1281.c
+++ b/simavr/cores/sim_mega1281.c
@@ -20,7 +20,6 @@
  */
 
 #include "sim_avr.h"
-#include "sim_core_declare.h"
 #include "avr_eeprom.h"
 #include "avr_flash.h"
 #include "avr_watchdog.h"
@@ -39,6 +38,8 @@ void m1281_reset(struct avr_t * avr);
 #define _AVR_IO_H_
 #define __ASSEMBLER__
 #include "avr/iom1281.h"
+
+#include "sim_core_declare.h"
 
 /*
  * This is a template for all of the 1281 devices, hopefully

--- a/simavr/cores/sim_mega128rfa1.c
+++ b/simavr/cores/sim_mega128rfa1.c
@@ -22,7 +22,6 @@
  */
 
 #include "sim_avr.h"
-#include "sim_core_declare.h"
 #include "avr_eeprom.h"
 #include "avr_flash.h"
 #include "avr_watchdog.h"
@@ -41,6 +40,8 @@ void m128rfa1_reset(struct avr_t * avr);
 #define _AVR_IO_H_
 #define __ASSEMBLER__
 #include "avr/iom128rfa1.h"
+
+#include "sim_core_declare.h"
 
 /*
  * This is a template for all of the 128rfa1 devices, hopefully

--- a/simavr/cores/sim_mega128rfr2.c
+++ b/simavr/cores/sim_mega128rfr2.c
@@ -22,7 +22,6 @@
  */
 
 #include "sim_avr.h"
-#include "sim_core_declare.h"
 #include "avr_eeprom.h"
 #include "avr_flash.h"
 #include "avr_watchdog.h"
@@ -41,6 +40,8 @@ void m128rfr2_reset(struct avr_t * avr);
 #define _AVR_IO_H_
 #define __ASSEMBLER__
 #include "avr/iom128rfr2.h"
+
+#include "sim_core_declare.h"
 
 /*
  * Temporary hack for mangled avr-libc headers

--- a/simavr/cores/sim_mega169.c
+++ b/simavr/cores/sim_mega169.c
@@ -3,7 +3,6 @@
  */
 
 #include "sim_avr.h"
-#include "sim_core_declare.h"
 #include "avr_eeprom.h"
 #include "avr_flash.h"
 #include "avr_watchdog.h"
@@ -29,6 +28,8 @@ void m169p_reset(struct avr_t * avr);
 #if defined(MCUSR) && !defined(MCUCSR)
 #define MCUCSR MCUSR
 #endif
+
+#include "sim_core_declare.h"
 
 const struct mcu_t {
 	avr_t          core;

--- a/simavr/cores/sim_mega2560.c
+++ b/simavr/cores/sim_mega2560.c
@@ -21,7 +21,6 @@
  */
 
 #include "sim_avr.h"
-#include "sim_core_declare.h"
 #include "avr_eeprom.h"
 #include "avr_flash.h"
 #include "avr_watchdog.h"
@@ -43,6 +42,8 @@ void m2560_reset(struct avr_t * avr);
 #define __AVR_ATmega2560__
 #endif
 #include "avr/iom2560.h"
+
+#include "sim_core_declare.h"
 
 /*
  * This is a template for all of the 2560 devices, hopefully

--- a/simavr/cores/sim_mega32u4.c
+++ b/simavr/cores/sim_mega32u4.c
@@ -36,7 +36,6 @@
 #define PE6	6
 
 #include "sim_avr.h"
-#include "sim_core_declare.h"
 #include "avr_eeprom.h"
 #include "avr_flash.h"
 #include "avr_watchdog.h"
@@ -59,6 +58,8 @@ void m32u4_reset(struct avr_t * avr);
 #define __AVR_ATmega32u4__
 #endif
 #include "avr/iom32u4.h"
+
+#include "sim_core_declare.h"
 
 /*
  * ATmega32u4 definitions

--- a/simavr/cores/sim_tiny13.c
+++ b/simavr/cores/sim_tiny13.c
@@ -21,7 +21,6 @@
  */
 
 #include "sim_avr.h"
-#include "sim_core_declare.h"
 #include "avr_eeprom.h"
 #include "avr_watchdog.h"
 #include "avr_extint.h"
@@ -33,6 +32,8 @@
 #define _AVR_IO_H_
 #define __ASSEMBLER__
 #include "avr/iotn13.h"
+
+#include "sim_core_declare.h"
 
 static void init(struct avr_t * avr);
 static void reset(struct avr_t * avr);

--- a/simavr/cores/sim_tiny2313.c
+++ b/simavr/cores/sim_tiny2313.c
@@ -19,7 +19,6 @@
 	along with simavr.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "sim_core_declare.h"
 #include "avr_eeprom.h"
 #include "avr_watchdog.h"
 #include "avr_extint.h"
@@ -34,6 +33,8 @@ static void reset(struct avr_t * avr);
 #define _AVR_IO_H_
 #define __ASSEMBLER__
 #include "avr/iotn2313.h"
+
+#include "sim_core_declare.h"
 
 /*
  * This is a template for all of the tinyx5 devices, hopefully

--- a/simavr/cores/sim_tiny2313a.c
+++ b/simavr/cores/sim_tiny2313a.c
@@ -19,7 +19,6 @@
 	along with simavr.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "sim_core_declare.h"
 #include "avr_eeprom.h"
 #include "avr_watchdog.h"
 #include "avr_extint.h"
@@ -34,6 +33,8 @@ static void reset(struct avr_t * avr);
 #define _AVR_IO_H_
 #define __ASSEMBLER__
 #include "avr/iotn2313a.h"
+
+#include "sim_core_declare.h"
 
 /*
  * This is a template for all of the tinyx5 devices, hopefully

--- a/simavr/cores/sim_tiny4313.c
+++ b/simavr/cores/sim_tiny4313.c
@@ -19,7 +19,6 @@
 	along with simavr.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "sim_core_declare.h"
 #include "avr_eeprom.h"
 #include "avr_watchdog.h"
 #include "avr_extint.h"
@@ -34,6 +33,8 @@ static void reset(struct avr_t * avr);
 #define _AVR_IO_H_
 #define __ASSEMBLER__
 #include "avr/iotn4313.h"
+
+#include "sim_core_declare.h"
 
 /*
  * This is a template for all of the tinyx5 devices, hopefully

--- a/simavr/cores/sim_usb162.c
+++ b/simavr/cores/sim_usb162.c
@@ -20,7 +20,6 @@
  */
 
 #include "sim_avr.h"
-#include "sim_core_declare.h"
 #include "avr_eeprom.h"
 #include "avr_flash.h"
 #include "avr_watchdog.h"
@@ -39,6 +38,8 @@ void usb162_reset(struct avr_t * avr);
 #define _AVR_IO_H_
 #define __ASSEMBLER__
 #include "avr/iousb162.h"
+
+#include "sim_core_declare.h"
 
 const struct mcu_t {
 	avr_t			 core;


### PR DESCRIPTION
For some parts sim_core_declare.h ends up included before the relevant AVR header. As a result ifdefs, such as ifdef SIGNATURE_0 is never true and stuff ends up missing