### PR TITLE
Fix timer mode 14 for timers 1, 3, 4 and 5 on Atmega2560

### DIFF
--- a/simavr/cores/sim_mega2560.c
+++ b/simavr/cores/sim_mega2560.c
@@ -275,7 +275,7 @@ const struct mcu_t {
 			 [7] = AVR_TIMER_WGM_FASTPWM10(),
 			 // TODO: 8, 9 PWM phase and freq correct ICR & 10, 11
 			 [12] = AVR_TIMER_WGM_ICCTC(),
-			 [14] = AVR_TIMER_WGM_ICPWM(),
+			 [14] = AVR_TIMER_WGM_ICFASTPWM(),
 			 [15] = AVR_TIMER_WGM_OCPWM(),
 		},
 		.cs = { AVR_IO_REGBIT(TCCR1B, CS10), AVR_IO_REGBIT(TCCR1B, CS11), AVR_IO_REGBIT(TCCR1B, CS12) },
@@ -401,7 +401,7 @@ const struct mcu_t {
 			 //		 10
 			 //		 11
 			 [12] = AVR_TIMER_WGM_ICCTC(),
-			 [14] = AVR_TIMER_WGM_ICPWM(),
+			 [14] = AVR_TIMER_WGM_ICFASTPWM(),
 			 [15] = AVR_TIMER_WGM_OCPWM(),
 		},
 		.cs = { AVR_IO_REGBIT(TCCR3B, CS30), AVR_IO_REGBIT(TCCR3B, CS31), AVR_IO_REGBIT(TCCR3B, CS32) },
@@ -478,7 +478,7 @@ const struct mcu_t {
 			 [7] = AVR_TIMER_WGM_FASTPWM10(),
 			 // TODO: 8, 9 PWM phase and freq correct ICR & 10, 11
 			 [12] = AVR_TIMER_WGM_ICCTC(),
-			 [14] = AVR_TIMER_WGM_ICPWM(),
+			 [14] = AVR_TIMER_WGM_ICFASTPWM(),
 			 [15] = AVR_TIMER_WGM_OCPWM(),
 		},
 		.cs = { AVR_IO_REGBIT(TCCR4B, CS40), AVR_IO_REGBIT(TCCR4B, CS41), AVR_IO_REGBIT(TCCR4B, CS42) },
@@ -556,7 +556,7 @@ const struct mcu_t {
 			 [7] = AVR_TIMER_WGM_FASTPWM10(),
 			 // TODO: 8, 9 PWM phase and freq correct ICR & 10, 11
 			 [12] = AVR_TIMER_WGM_ICCTC(),
-			 [14] = AVR_TIMER_WGM_ICPWM(),
+			 [14] = AVR_TIMER_WGM_ICFASTPWM(),
 			 [15] = AVR_TIMER_WGM_OCPWM(),
 		},
 		.cs = { AVR_IO_REGBIT(TCCR5B, CS50), AVR_IO_REGBIT(TCCR5B, CS51), AVR_IO_REGBIT(TCCR5B, CS52) },

--- a/simavr/sim/avr_timer.c
+++ b/simavr/sim/avr_timer.c
@@ -575,9 +575,12 @@ avr_timer_reconfigure(
 				_timer_get_ocr(p, AVR_TIMER_COMPA) : _timer_get_icr(p);
 			avr_timer_configure(p, p->cs_div_value, top, reset);
 		}	break;
-		case avr_timer_wgm_fast_pwm:
-			avr_timer_configure(p, p->cs_div_value, p->wgm_op_mode_size, reset);
-			break;
+		case avr_timer_wgm_fast_pwm: {
+			uint16_t top =
+				(p->mode.top == avr_timer_wgm_reg_icr) ? _timer_get_icr(p) :
+				p->wgm_op_mode_size;
+			avr_timer_configure(p, p->cs_div_value, top, reset);
+		}	break;
 		case avr_timer_wgm_none:
 			avr_timer_configure(p, p->cs_div_value, p->wgm_op_mode_size, reset);
 			break;

--- a/simavr/sim/avr_timer.h
+++ b/simavr/sim/avr_timer.h
@@ -104,6 +104,7 @@ typedef struct avr_timer_wgm_t {
 #define AVR_TIMER_WGM_FCPWM10() { .kind = avr_timer_wgm_fc_pwm, .size=10 }
 #define AVR_TIMER_WGM_OCPWM() { .kind = avr_timer_wgm_pwm, .top = avr_timer_wgm_reg_ocra }
 #define AVR_TIMER_WGM_ICPWM() { .kind = avr_timer_wgm_pwm, .top = avr_timer_wgm_reg_icr }
+#define AVR_TIMER_WGM_ICFASTPWM() { .kind = avr_timer_wgm_fast_pwm, .top = avr_timer_wgm_reg_icr }
 
 typedef struct avr_timer_comp_t {
 		avr_int_vector_t	interrupt;		// interrupt vector


### PR DESCRIPTION
According to documentation, modes 14 and 15 for timers 1, 3, 4 and 5 are, respectively, Fast PWM with TOP = ICRn and Fast PWM with TOP = OCRnA. Current code considered them regular PWM, and accordingly (avr_timer.c:579) set their TOP to the "size" value, which is undefined for these modes.

It happened I needed mode 14. I'm simulating an Arduino Mega board, and my Arduino program uses the Adafruit_TiCoServo library. This lib uses mode 14 to generate a PWM pulse to control servos, so as not to rely on interrupts as the Arduino Servo lib does.

I only fixed mode 14 (mode 15 should be straightforward too, but I don't have time to test it) and only tested it with timer 3, though there's no reason it shouldn't work with other timers.

I can provide a simple test case if needed, when I have the time. Something like this should do:
``` Arduino
#include <Adafruit_TiCoServo.h>

Adafruit_TiCoServo servo;

void setup()
{
        servo.attach(3);
        servo.write(50);
}

void loop()
{
}
```

And corresponding code to simulate the board. The program hangs on [Adafruit_TiCoServo.cpp:258](https://github.com/adafruit/Adafruit_TiCoServo/blob/master/Adafruit_TiCoServo.cpp#L258): `*counter`  (that is, TCNT3) never gets past 0, because tov_top is set to 0.