### PR TITLE
use READ_SREG_INTO rather than g->avr->data[R_SREG] in sim_gdb.c

### DIFF
--- a/simavr/sim/sim_gdb.c
+++ b/simavr/sim/sim_gdb.c
@@ -199,9 +199,12 @@ gdb_send_quick_status(
 		uint8_t signal )
 {
 	char cmd[64];
+	uint8_t sreg;
+
+	READ_SREG_INTO(g->avr, sreg);
 
 	sprintf(cmd, "T%02x20:%02x;21:%02x%02x;22:%02x%02x%02x00;",
-		signal ? signal : 5, g->avr->data[R_SREG],
+		signal ? signal : 5, sreg,
 		g->avr->data[R_SPL], g->avr->data[R_SPH],
 		g->avr->pc & 0xff, (g->avr->pc>>8)&0xff, (g->avr->pc>>16)&0xff);
 	gdb_send_reply(g, cmd);
@@ -577,8 +580,11 @@ avr_gdb_handle_watchpoints(
 	if (kind & type) {
 		/* Send gdb reply (see GDB user manual appendix E.3). */
 		char cmd[78];
+		uint8_t sreg;
+
+		READ_SREG_INTO(g->avr, sreg);
 		sprintf(cmd, "T%02x20:%02x;21:%02x%02x;22:%02x%02x%02x00;%s:%06x;",
-				5, g->avr->data[R_SREG],
+				5, sreg,
 				g->avr->data[R_SPL], g->avr->data[R_SPH],
 				g->avr->pc & 0xff, (g->avr->pc>>8)&0xff, (g->avr->pc>>16)&0xff,
 				kind & AVR_GDB_WATCH_ACCESS ? "awatch" :


### PR DESCRIPTION
Someone pointed out to me that the gdb command "info registers SREG" can return incorrect output if not preceded by a "info registers" call to refresh all registers.  

I tracked this down to the code in gdb_send_quick_status() that seems to use an incorrect or obsolete method to get SREG and push it over to gdb.  I copied over the gdb_read_register version, which used READ_SREG_INTO and seemed to be correct.

This may be unnecessary if your sreg-inline changes alter how the status register is stored, but I suspect it is safe either way.
