### PR TITLE
Fixed off-by-one in strnpy bound

### DIFF
--- a/simavr/sim/run_avr.c
+++ b/simavr/sim/run_avr.c
@@ -105,10 +105,12 @@ main(
 		} else if (!strcmp(argv[pi], "-h") || !strcmp(argv[pi], "--help")) {
 			display_usage(basename(argv[0]));
 		} else if (!strcmp(argv[pi], "-m") || !strcmp(argv[pi], "--mcu")) {
-			if (pi < argc-1)
-				strncpy(name, argv[++pi], sizeof(name));
-			else
+			if (pi < argc-1) {
+				strncpy(name, argv[++pi], sizeof(name)-1);
+				name[sizeof(name)-1] = '\0';
+			} else {
 				display_usage(basename(argv[0]));
+			}
 		} else if (!strcmp(argv[pi], "-f") || !strcmp(argv[pi], "--freq")) {
 			if (pi < argc-1)
 				f_cpu = atoi(argv[++pi]);


### PR DESCRIPTION
`-Werror` being enabled in `sim/Makefile`, `make` fails for me with the following error:
```c
sim/run_avr.c: In function ‘main’:
sim/run_avr.c:109:5: error: ‘strncpy’ specified bound 24 equals destination size [-Werror=stringop-truncation]
     strncpy(name, argv[++pi], sizeof(name));
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```
This patch fixes that and sets the last byte to zero in case the input was exactly `sizeof(name)-1` bytes long (then `strncpy` will not null-terminate the string, as per the relevant `man` page).