### PR TITLE
Forcibly null terminate input strings

### DIFF
--- a/simavr/sim/run_avr.c
+++ b/simavr/sim/run_avr.c
@@ -106,7 +106,7 @@ main(
 			display_usage(basename(argv[0]));
 		} else if (!strcmp(argv[pi], "-m") || !strcmp(argv[pi], "--mcu")) {
 			if (pi < argc-1)
-				strncpy(name, argv[++pi], sizeof(name));
+				snprintf(name, sizeof(name), "%s", argv[++pi]);
 			else
 				display_usage(basename(argv[0]));
 		} else if (!strcmp(argv[pi], "-f") || !strcmp(argv[pi], "--freq")) {
@@ -127,7 +127,7 @@ main(
 				exit(1);
 			}
 			++pi;
-			strncpy(f.tracename, argv[pi], sizeof(f.tracename));
+			snprintf(f.tracename, sizeof(f.tracename), "%s",  argv[pi]);
 		} else if (!strcmp(argv[pi], "--add-vcd-trace")) {
 			if (pi + 1 >= argc) {
 				fprintf(stderr, "%s: missing mandatory argument for %s.\n", argv[0], argv[pi]);
@@ -190,7 +190,7 @@ main(
 				fprintf(stderr, "%s: missing mandatory argument for %s.\n", argv[0], argv[pi]);
 				exit(1);
 			}
-			strncpy(f.tracename, argv[++pi], sizeof(f.tracename));
+			snprintf(f.tracename, sizeof(f.tracename), "%s", argv[++pi]);
 		} else if (!strcmp(argv[pi], "-ti")) {
 			if (pi < argc-1)
 				trace_vectors[trace_vectors_count++] = atoi(argv[++pi]);


### PR DESCRIPTION
As described in issue #293 GCC 8 fails the build in the current
configuration on warnings like:

sim/run_avr.c:193:4: error: ‘strncpy’ specified bound 128
equals destination size [-Werror=stringop-truncation]
    strncpy(f.tracename, argv[++pi], sizeof(f.tracename));

This isn't the only solution, but it get's the build working.

```$ make
make -C simavr RELEASE=0
make[1]: Entering directory '/home/doug/git/simavr/simavr'
make obj config
make[2]: Entering directory '/home/doug/git/simavr/simavr'
make[2]: Nothing to be done for 'obj'.
make[2]: Nothing to be done for 'config'.
make[2]: Leaving directory '/home/doug/git/simavr/simavr'
make libsimavr run_avr
make[2]: Entering directory '/home/doug/git/simavr/simavr'
make[2]: Nothing to be done for 'libsimavr'.
CC sim/run_avr.c
sim/run_avr.c: In function ‘main’:
sim/run_avr.c:193:4: error: ‘strncpy’ specified bound 128 equals destination size [-Werror=stringop-truncation]
    strncpy(f.tracename, argv[++pi], sizeof(f.tracename));
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
sim/run_avr.c:130:4: error: ‘strncpy’ specified bound 128 equals destination size [-Werror=stringop-truncation]
    strncpy(f.tracename, argv[pi], sizeof(f.tracename));
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
sim/run_avr.c:109:5: error: ‘strncpy’ specified bound 24 equals destination size [-Werror=stringop-truncation]
     strncpy(name, argv[++pi], sizeof(name));
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[2]: *** [../Makefile.common:184: obj-x86_64-redhat-linux/run_avr.o] Error 1
make[2]: Leaving directory '/home/doug/git/simavr/simavr'
make[1]: *** [Makefile:34: all] Error 2
make[1]: Leaving directory '/home/doug/git/simavr/simavr'
make: *** [Makefile:18: build-simavr] Error 2
```
```
$ gcc --version
gcc (GCC) 8.1.1 20180502 (Red Hat 8.1.1-1)
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```