### PR TITLE
Fix receiving after fifo overrun

### DIFF
--- a/examples/parts/uart_pty.c
+++ b/examples/parts/uart_pty.c
@@ -175,8 +175,6 @@ uart_pty_thread(
 		struct timeval timo = { 0, 500 };
 		int ret = select(max+1, &read_set, &write_set, NULL, &timo);
 
-		if (!ret)
-			continue;
 		if (ret < 0)
 			break;
 


### PR DESCRIPTION
After fifo overrun buffer_done remains less than buffer_len and
FD_SET(p->port[ti].s, &read_set) is not called. If firmware has nothing
to send, select always returns 0 and new data is never read even if
fifo buffer gets flushed.
This patch removes check for select timeout, so the remaining data in
buffer may go to fifo.