### PR TITLE
Fix timer1 on tinyx5

### DIFF
--- a/simavr/cores/sim_tinyx5.h
+++ b/simavr/cores/sim_tinyx5.h
@@ -200,9 +200,13 @@ const struct mcu_t SIM_CORENAME = {
 	},
 	.timer1 = {
 		.name = '1',
-		// no wgm bits
+		// timer1 has no wgm bits, but we still need to define a wgm op so that
+		// we can set a proper kind/size to the timer
+		.wgm_op = {
+			[0] = AVR_TIMER_WGM_NORMAL8(),
+		},
 		.cs = { AVR_IO_REGBIT(TCCR1, CS10), AVR_IO_REGBIT(TCCR1, CS11), AVR_IO_REGBIT(TCCR1, CS12), AVR_IO_REGBIT(TCCR1, CS13) },
-		.cs_div = { 0, 0, 1 /* 2 */, 2 /* 4 */, 3 /* 8 */, 4 /* 16 */ },
+		.cs_div = { 0, 0, 1 /* 2 */, 2 /* 4 */, 3 /* 8 */, 4 /* 16 */, 5 /* 32 */, 6 /* 64 */, 7 /* 128 */, 8 /* 256 */, 9 /* 512 */, 10 /* 1024 */, 11 /* 2048 */, 12 /* 4096 */, 13 /* 8192 */, 14 /* 16384 */ },
 
 		.r_tcnt = TCNT1,
 


### PR DESCRIPTION
The prescaler list for timer1 on the tinyx5 was incomplete. Moreover,
having no WGM data made the timer run in `avr_timer_wgm_none`, with a
zero size (it would overflow all the time).

Setting a default wgm_op makes time timer run in normal mode witha size
of 8 bits.

I have a program to reproduce the problem at https://github.com/hsoft/avr-asm/tree/master/timer1_tn45 . When I load this program on a real attiny45, PB0 blinks properly.