### PR TITLE
Note that it is possible to install through Aptitude

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ On OSX, we recommend using [homebrew](https://brew.sh):
     brew tap osx-cross/avr
     brew install --HEAD simavr
 
+On Ubuntu, SimAVR is available in the Bionic package source:
+
+    apt-get install simavr
+
+(Note that the command is made available under the name `simavr` not `run_avr`.)
+
 Otherwise, `make` is enough to just start using __bin/simavr__. To install the __simavr__ command system-wide, `make install RELEASE=1`.
 
 Supported IOs


### PR DESCRIPTION
I've found that there is a maintainer who publishes SimAVR for Ubuntu here:
https://packages.ubuntu.com/bionic/simavr

Seems to be kept reasonably up-to-date (the latest there is 1.15 whereasy here on GitHub it is 1.16).
I know that maintainers do not always keep in contact with the software vendor so I would not be surprised to learn you were not aware of this. If you are okay with it though and consider it to be a legit enough source, I figure it's good to call that out in the README.

BTW this probably also works on Debian, but I didn't try it there so I stuck to what I knew for a fact worked.