### PR TITLE
added OC0A/OC0B support for attiny13

### DIFF
--- a/simavr/cores/sim_tiny13.c
+++ b/simavr/cores/sim_tiny13.c
@@ -106,6 +106,8 @@ static const struct mcu_t {
 		.comp = {
 			[AVR_TIMER_COMPA] = {
 				.r_ocr = OCR0A,
+				.com = AVR_IO_REGBITS(TCCR0A, COM0A0, 0x3),
+				.com_pin = AVR_IO_REGBIT(PORTB, 0),
 				.interrupt = {
 					.enable = AVR_IO_REGBIT(TIMSK0, OCIE0A),
 					.raised = AVR_IO_REGBIT(TIFR0, OCF0A),
@@ -114,6 +116,8 @@ static const struct mcu_t {
 			},
 			[AVR_TIMER_COMPB] = {
 				.r_ocr = OCR0B,
+				.com = AVR_IO_REGBITS(TCCR0A, COM0B0, 0x3),
+				.com_pin = AVR_IO_REGBIT(PORTB, 1),
 				.interrupt = {
 					.enable = AVR_IO_REGBIT(TIMSK0, OCIE0B),
 					.raised = AVR_IO_REGBIT(TIFR0, OCF0B),


### PR DESCRIPTION
The "settings" .com and .com_pin settings for timer0 in section .comp were missed, so the OC0A / OC0B toggling (or the other modes) never occured.