### PR TITLE
doc: Listing out dependencies when installing from source on Ubuntu 1…

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,13 @@ On Ubuntu, SimAVR is available in the Bionic package source:
 
 (Note that the command is made available under the name `simavr` not `run_avr`.)
 
-Otherwise, `make` is enough to just start using __bin/simavr__. To install the __simavr__ command system-wide, `make install RELEASE=1`.
+Installing from source on Ubuntu 18.04:
+
+	sudo apt-get install pkg-config libelf-dev freeglut3-dev libncurses5-dev gcc-avr avr-libc
+	make
+	make install RELEASE=1 # Optional
+
+`make` is enough to just start using __bin/simavr__. To install the __simavr__ command system-wide, run `make install RELEASE=1`.
 
 Supported IOs
 --------------


### PR DESCRIPTION
doc: Listing out dependencies when installing from source on Ubuntu 18.04

This is another variation on the similar pull requests #283 , #305 
It would be really helpful to have the dependencies listed out in the README in one way or another.