### PR TITLE
Speed up response time while waiting for timers with CPU in sleep state

### DIFF
--- a/simavr/sim/sim_avr.c
+++ b/simavr/sim/sim_avr.c
@@ -382,8 +382,9 @@ avr_callback_run_raw(
 			return;
 		}
 		/*
-		 * try to sleep for as long as we can (?)
+		 * try to sleep for as long as we can, capped at 1 ms
 		 */
+		if (sleep > 1000) sleep = 1000;
 		avr->sleep(avr, sleep);
 		avr->cycle += 1 + sleep;
 	}

--- a/simavr/sim/sim_avr.c
+++ b/simavr/sim/sim_avr.c
@@ -319,8 +319,9 @@ avr_callback_run_gdb(
 			return;
 		}
 		/*
-		 * try to sleep for as long as we can (?)
+		 * try to sleep for as long as we can, capped at 1 ms
 		 */
+		if (sleep > 1000) sleep = 1000;
 		avr->sleep(avr, sleep);
 		avr->cycle += 1 + sleep;
 	}


### PR DESCRIPTION
When the CPU is put to sleep and we are only waiting on timer events, the
simulator will wait for the event to fire before continuing.  On a slow CPU
with a 16 bit timer, this delay could amount to multiple seconds so the
thread running the AVR simulator will be waiting for all that time.  This
patch puts a 1 millisecond limit on the time waiting in such scenarios.
Note that powering down the CPU pending an interrupt already results in a
non-waiting behaviour such as this.