### PR TITLE
Fix a bug in the bitmask inside _avr_is_instruction_32_bits() function in sim_core.c file.

### DIFF
--- a/simavr/sim/sim_core.c
+++ b/simavr/sim/sim_core.c
@@ -590,7 +590,7 @@ _avr_flags_znv0s (struct avr_t * avr, uint8_t res)
 
 static inline int _avr_is_instruction_32_bits(avr_t * avr, avr_flashaddr_t pc)
 {
-	uint16_t o = _avr_flash_read16le(avr, pc) & 0xfc0f;
+	uint16_t o = _avr_flash_read16le(avr, pc) & 0xfe0f;
 	return	o == 0x9200 || // STS ! Store Direct to Data Space
 			o == 0x9000 || // LDS Load Direct from Data Space
 			o == 0x940c || // JMP Long Jump


### PR DESCRIPTION
Fix a bug in the bitmask of _avr_is_instruction_32_bits() function which can lead to misinterpret certain opcodes length.

For example:
                   sbiw r24, 0x1c   (1001 0111 0100 1100) (0x974c)
with current bitmask: (0xfc0f)
                   1001 0111 0100 1100 &
                   1111 1100 0000 1111 =
                   1001 0100 0000 1100  (0x940c)

0x940c matches as JMP in _avr_is_instruction_32_bits() function which has 32 bits opcode,
but SBIW has a 16 bit opcode, so the function interprets SBIW as an instruction with a 32 bits opcode.

The proposed new bitmask is 0xfe0f.