### PR TITLE
Compare address with I/O end address in _avr_set_ram

### DIFF
--- a/simavr/sim/sim_core.c
+++ b/simavr/sim/sim_core.c
@@ -243,7 +243,7 @@ inline void _avr_sp_set(avr_t * avr, uint16_t sp)
  */
 static inline void _avr_set_ram(avr_t * avr, uint16_t addr, uint8_t v)
 {
-	if (addr < MAX_IOs + 31)
+	if (addr <= avr->ioend)
 		_avr_set_r(avr, addr, v);
 	else
 		avr_core_watch_write(avr, addr, v);


### PR DESCRIPTION
In _avr_set_ram, we check if the address is smaller than `MAX_IOs + 31`
to know if it is a register or SRAM location.  In reality, many devices
have less I/Os than that, so the SRAM begins before this address.

As shown in issue #372, this causes watchpoints to not be triggered when
writing to an SRAM location that is smaller than `MAX_IOs + 31`.  For
example, a global variable on an atmega328 gets placed at address 0x100,
which is less than `MAX_IOs + 31`.

Fix this by comparing the address to the `ioend` property of `avr`.

Fixes #372