### PR TITLE
used attribute for _MMCU_ , should avoid dropping the .mmcu section

### DIFF
--- a/simavr/sim/avr/avr_mcu_section.h
+++ b/simavr/sim/avr/avr_mcu_section.h
@@ -80,7 +80,7 @@ enum {
  * So the new method declares the string as fixed size, and the parser
  * is forced to skip the zeroes in padding. Dumbo.
  */
-#define _MMCU_ __attribute__((section(".mmcu")))
+#define _MMCU_ __attribute__((section(".mmcu"))) __attribute__((used))
 struct avr_mmcu_long_t {
 	uint8_t tag;
 	uint8_t len;


### PR DESCRIPTION
Fix for issue #285, #378.
Follows the suggestion from https://gcc.gnu.org/wiki/LinkTimeOptimizationFAQ