### PR TITLE
Terminate the simulation on exit() from firmware

### DIFF
--- a/simavr/sim/sim_avr.c
+++ b/simavr/sim/sim_avr.c
@@ -282,6 +282,16 @@ avr_callback_sleep_gdb(
 		;
 }
 
+static void
+gracefully_quit(
+		avr_t * avr,
+		const char * reason)
+{
+	if (avr->log)
+		AVR_LOG(avr, LOG_TRACE, "simavr: %s, quitting gracefully\n", reason);
+	avr->state = cpu_Done;
+}
+
 void
 avr_callback_run_gdb(
 		avr_t * avr)
@@ -309,13 +319,16 @@ avr_callback_run_gdb(
 	// until the next timer is due
 	avr_cycle_count_t sleep = avr_cycle_timer_process(avr);
 
+	if (avr->state == cpu_Running && new_pc == avr->pc && avr->flash[new_pc] == 0xff && avr->flash[new_pc+1] == 0xcf && !avr->sreg[S_I]) {
+		gracefully_quit(avr, "rjmp .-2 with interrupts off");
+		return;
+	}
+
 	avr->pc = new_pc;
 
 	if (avr->state == cpu_Sleeping) {
 		if (!avr->sreg[S_I]) {
-			if (avr->log)
-				AVR_LOG(avr, LOG_TRACE, "simavr: sleeping with interrupts off, quitting gracefully\n");
-			avr->state = cpu_Done;
+			gracefully_quit(avr, "sleeping with interrupts off");
 			return;
 		}
 		/*
@@ -372,13 +385,16 @@ avr_callback_run_raw(
 	// until the next timer is due
 	avr_cycle_count_t sleep = avr_cycle_timer_process(avr);
 
+	if (avr->state == cpu_Running && new_pc == avr->pc && avr->flash[new_pc] == 0xff && avr->flash[new_pc+1] == 0xcf && !avr->sreg[S_I]) {
+		gracefully_quit(avr, "rjmp .-2 with interrupts off");
+		return;
+	}
+
 	avr->pc = new_pc;
 
 	if (avr->state == cpu_Sleeping) {
 		if (!avr->sreg[S_I]) {
-			if (avr->log)
-				AVR_LOG(avr, LOG_TRACE, "simavr: sleeping with interrupts off, quitting gracefully\n");
-			avr->state = cpu_Done;
+			gracefully_quit(avr, "sleeping with interrupts off");
 			return;
 		}
 		/*


### PR DESCRIPTION
The firmware can end the simulation by sleeping with interrupts disabled. While this way of hanging the CPU makes a lot of sense, it is not the most intuitive.

The standard way to terminate a C program is by either calling `exit()` or returning from `main()`. It turns out the AVR C runtime supports stopping the firmware in both these standard ways. Returning from `main()` jumps to `exit()`, which disables interrupts and hangs the CPU in an infinite loop. The implementation is roughly like this:

```lisp
; after the C runtime initializations:
.section .init9
    call main  ; run the firmware
    jmp exit   ; if main() returns, go to exit()

exit:
_exit:
    cli        ; disable interrupts
    rjmp .-2   ; hang the CPU
```

This pull request makes run_avr gracefully quit if the firmware executes the CPU-hanging instruction `rjmp .-2` with interrupts disabled.

The actual condition used in the code is:

```c
if (avr->state == cpu_Running && new_pc == avr->pc
    && avr->flash[new_pc] == 0xff && avr->flash[new_pc+1] == 0xcf
    && !avr->sreg[S_I])
```

Some of those tests may be redundant but, as I am not sure to understand all the subtleties of the simulation, I opted for defensive programming.

The feature has been tested with the following program:

```c
#include <stdlib.h>
#include <avr/io.h>
#include <avr/sleep.h>
#include "avr_mcu_section.h"

AVR_MCU(F_CPU, "atmega328p");
AVR_MCU_SIMAVR_CONSOLE(&GPIOR0);

int main(void)
{
    const char *s = "Exiting.\r\n";
    for (const char *t = s; *t; t++)
        GPIOR0 = *t;
#if defined(QUIT_BY_SLEEP)
    sleep_mode();
#elif defined(QUIT_BY_EXIT)
    exit(0);
#endif
}
```