### PR TITLE
Support for GDB monitor commands

### DIFF
--- a/simavr/sim/sim_gdb.c
+++ b/simavr/sim/sim_gdb.c
@@ -359,14 +359,11 @@ gdb_handle_command(
 							avr->state = cpu_StepDone;
 							avr_reset(avr);
 							args += 10;
-							printf("Reset\n"); // Remove
 						} else if (strncmp(args, "68616c74", 8) == 0) { // halt matched
 							avr->state = cpu_Stopped;
 							args += 8;
-							printf("Halting\n"); // Remove
 						} else if (strncmp(args, "20", 2) == 0) { // space matched
 							args += 2;
-							printf("Space\n"); // Remove
 						}
 						else{ // no match - end
 							break;
@@ -526,7 +523,6 @@ gdb_handle_command(
 		case 'D': {	// detach
 			avr->state = cpu_Done;
 			gdb_send_reply(g, "OK");
-			printf("Halted\n"); // Remove
 		}	break;
 		default:
 			gdb_send_reply(g, "");

--- a/simavr/sim/sim_gdb.c
+++ b/simavr/sim/sim_gdb.c
@@ -350,10 +350,9 @@ gdb_handle_command(
 				}
 			} else if (strncmp(cmd, "Rcmd", 4) == 0) { // monitor command
 				char * args = strchr(cmd, ',');
-				if (args != NULL)
-				{
+				if (args != NULL) {
 					args++;
-					while(args != 0x00) {
+					while (args != 0x00) {
 						printf("%s",args);
 						if (strncmp(args, "7265736574", 10) == 0) { // reset matched
 							avr->state = cpu_StepDone;
@@ -364,10 +363,8 @@ gdb_handle_command(
 							args += 8;
 						} else if (strncmp(args, "20", 2) == 0) { // space matched
 							args += 2;
-						}
-						else{ // no match - end
+						} else // no match - end
 							break;
-						}
 					}
 				}
 				gdb_send_reply(g, "OK");


### PR DESCRIPTION
new gdb commands kill, detach and monitor
monitor parser supports reset and halt words but can be easily extended
improves [integration](https://community.platformio.org/t/avr-simulator-as-aid-tool-for-debugging-code/13444) into development environments like PlatformIO
fix issue #370