### PR TITLE
Support for non-aligned PCINTs

### DIFF
--- a/simavr/cores/sim_mega2560.h
+++ b/simavr/cores/sim_mega2560.h
@@ -102,7 +102,17 @@ const struct mcu_t {
 	AVR_IOPORT_DECLARE(f, 'F', F),
 	AVR_IOPORT_DECLARE(g, 'G', G),
 	AVR_IOPORT_DECLARE(h, 'H', H),
-	AVR_IOPORT_DECLARE(j, 'J', J),
+	.portj = {
+		.name = 'J', .r_port = PORTJ, .r_ddr = DDRJ, .r_pin = PINJ,
+		.pcint = {
+			 .enable = AVR_IO_REGBIT(PCICR, PCIE1),
+			 .raised = AVR_IO_REGBIT(PCIFR, PCIF1),
+			 .vector = PCINT1_vect,
+			 .mask = 0b11111110,
+			 .shift = -1
+		},
+		.r_pcint = PCMSK1,
+	},
 	AVR_IOPORT_DECLARE(k, 'K', K),
 	AVR_IOPORT_DECLARE(l, 'L', L),
 
@@ -353,7 +363,7 @@ const struct mcu_t {
 		.r_tcnt = TCNT2,
 		// asynchronous timer source bit.. if set, use 32khz frequency
 		.as2 = AVR_IO_REGBIT(ASSR, AS2),
-		
+
 		.overflow = {
 			 .enable = AVR_IO_REGBIT(TIMSK2, TOIE2),
 			 .raised = AVR_IO_REGBIT(TIFR2, TOV2),

--- a/simavr/sim/sim_interrupts.h
+++ b/simavr/sim/sim_interrupts.h
@@ -42,6 +42,9 @@ typedef struct avr_int_vector_t {
 	avr_regbit_t 	enable;			// IO register index for the "interrupt enable" flag for this vector
 	avr_regbit_t 	raised;			// IO register index for the register where the "raised" flag is (optional)
 
+	uint8_t 		mask; // Mask for PCINTs. this is needed for chips like the 2560 where PCINT do not align with IRQs
+	int8_t 		shift;	// PCINT8 = E0, PCINT9-15 are on J0-J6. Shift shifts down (<0) or up (>0) for alignment with IRQ#.
+
 	// 'pending' IRQ, and 'running' status as signaled here
 	avr_irq_t		irq[AVR_INT_IRQ_COUNT];
 	uint8_t			pending : 1,	// 1 while scheduled in the fifo


### PR DESCRIPTION
Some chips have PCINT setups that are not aligned with ports. 
For example, the 2560 has PCINT8 on E0, and PCINT9-15 on J0-6

This adds a mask and shift option to the PCINT declaration to support this. 

The default mask behaviour is that if mask = 0 (no PCINTs, this doesn't make sense in a normal context) then the behaviour is as before. If mask and/or shift are defined, the bitfield is shifted appropriately to align it with the expectation for the & with irq->irq. 

Also includes a fix for PORTJ on the 2560 to enable its PCINTs using this.