### PR TITLE
Increase max number of shared io callbacks.

### DIFF
--- a/simavr/sim/sim_avr.h
+++ b/simavr/sim/sim_avr.h
@@ -67,6 +67,9 @@ enum {
 
 	// maximum number of IO registers, on normal AVRs
 	MAX_IOs	= 280,	// Bigger AVRs need more than 256-32 (mega1280)
+	// maximum number of callbacks that can be registered for a
+	// single register
+	MAX_REGISTER_CBs = 256,
 };
 
 #define AVR_DATA_TO_IO(v) ((v) - 32)
@@ -300,8 +303,8 @@ typedef struct avr_t {
 		struct {
 			void * param;
 			void * c;
-		} io[4];
-	} io_shared_io[4];
+		} io[MAX_REGISTER_CBs];
+	} io_shared_io[MAX_IOs];
 
 	// flash memory (initialized to 0xff, and code loaded into it)
 	uint8_t *		flash;


### PR DESCRIPTION
This change allows potentially all IO registers to have multiple read/write callbacks registered for them. The current number (4) is too low to be useful in broader contexts, and I don't see a reason why this couldn't be increased to `MAX_IOs`.

Also included is `MAX_REGISTER_CBs`, a limit to the maximum number of callbacks that can be registered for a given IO register. Arbitrarily chosen to be 256.