### PR TITLE
Update links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ graphically as “waveforms” with tools like _gtkwave_ (see below).
 Documentation And Further Information
 -------------------------------------
 
-* Manual / Developer Guide: https://github.com/buserror-uk/simavr/blob/master/doc/manual/manual.pdf?raw=true
-* Examples: https://github.com/buserror-uk/simavr/tree/master/examples
-* Mailing List: http://groups.google.com/group/simavr
+* [Manual / Developer Guide](doc/manual/manual.pdf?raw=true)
+* [Examples](examples)
+* [Mailing List](https://groups.google.com/g/simavr)
 * IRC: _#simavr_ on Freenode
 
 Contributing
@@ -114,7 +114,7 @@ a file that will display:
 	simavr: sleeping with interrupts off, quitting gracefully
 
 And when the file is loaded in gtkwave, you see:
-![gtkwave](https://github.com/buserror-uk/simavr/raw/master/doc/img/gtkwave1.png)
+![gtkwave](doc/img/gtkwave1.png)
 
 You get a very precise timing breakdown of any change that you add to the trace, down
 to the AVR cycle. 
@@ -137,13 +137,13 @@ need to generate the proper stimulus so that the AVR is fooled.
 HD44780 LCD Board Demo
 ----------------------
 
-![lcd](https://github.com/buserror-uk/simavr/raw/master/doc/img/hd44780.png)
+![lcd](doc/img/hd44780.png)
 
 This example board hooks up an Atmega48 to an emulated HD44780 LCD and display a running
 counter in the 'lcd'. Everything is emulated, the firmware runs exactly like this
 on a real hardware.
 
-![lcd-gtkwave](https://github.com/buserror-uk/simavr/raw/master/doc/img/hd44780-wave.png)
+![lcd-gtkwave](doc/img/hd44780-wave.png)
 
 And this is a gtkwave trace of what the firmware is doing. You can zoom in, measure, etc
 in gtkwave, select trades to see etc.


### PR DESCRIPTION
- Replace absolute links into github's buserror-uk/simavr repo with
  relative local links. (This also helps to follow-up the repo slug
  change to buserror/simavr.)
- Turn URLs into markdown inline links.
- Update mailing list URL to use https.