### PR TITLE
Add new USB ioctl to start SOFI cycle timer

### DIFF
--- a/simavr/sim/avr_usb.c
+++ b/simavr/sim/avr_usb.c
@@ -686,6 +686,7 @@ avr_usb_ioctl(
 		case AVR_IOCTL_USB_RESET_AND_SOFI:
 			// register SOFI every 1ms and fallthrough to reset.
 			avr_cycle_timer_register_usec(io->avr, 1000, sof_generator, p);
+			// fallthrough
 		case AVR_IOCTL_USB_RESET:
 			AVR_LOG(io->avr, LOG_TRACE, "USB: __USB_RESET__\n");
 			reset_endpoints(io->avr, p);
@@ -798,4 +799,3 @@ void avr_usb_init(avr_t * avr, avr_usb_t * p)
 
 	avr_register_io_write(avr, p->r_pllcsr, avr_usb_pll_write, p);
 }
-

--- a/simavr/sim/avr_usb.c
+++ b/simavr/sim/avr_usb.c
@@ -20,7 +20,6 @@
  */
 
 /* TODO correct reset values */
-/* TODO generate sofi every 1ms (when connected) */
 /* TODO otg support? */
 /* TODO drop bitfields? */
 /* TODO thread safe ioctls */
@@ -684,12 +683,13 @@ avr_usb_ioctl(
 			raise_ep_interrupt(io->avr, p, ep, rxstpi);
 
 			return 0;
+		case AVR_IOCTL_USB_RESET_AND_SOFI:
+			// register SOFI every 1ms and fallthrough to reset.
+			avr_cycle_timer_register_usec(io->avr, 1000, sof_generator, p);
 		case AVR_IOCTL_USB_RESET:
 			AVR_LOG(io->avr, LOG_TRACE, "USB: __USB_RESET__\n");
 			reset_endpoints(io->avr, p);
 			raise_usb_interrupt(p, eorsti);
-			if (0)
-				avr_cycle_timer_register_usec(io->avr, 1000, sof_generator, p);
 			return 0;
 		default:
 			return -1;

--- a/simavr/sim/avr_usb.h
+++ b/simavr/sim/avr_usb.h
@@ -38,6 +38,7 @@ enum {
 #define AVR_IOCTL_USB_READ AVR_IOCTL_DEF('u','s','b','r')
 #define AVR_IOCTL_USB_SETUP AVR_IOCTL_DEF('u','s','b','s')
 #define AVR_IOCTL_USB_RESET AVR_IOCTL_DEF('u','s','b','R')
+#define AVR_IOCTL_USB_RESET_AND_SOFI AVR_IOCTL_DEF('u','s','b','S')
 #define AVR_IOCTL_USB_VBUS AVR_IOCTL_DEF('u','s','b','V')
 #define AVR_IOCTL_USB_GETIRQ() AVR_IOCTL_DEF('u','s','b',' ')
 


### PR DESCRIPTION
This PR adds a new USB ioctl, `AVR_IOCTL_USB_RESET_AND_SOFI`. This is the same as `AVR_IOCTL_USB_RESET`, but it also registers a cycle timer to raise a USB SOFI (start of frame interrupt) every 1ms, which is consistent with USB full speed bus cycle time.

The code for this already existed but was disabled for some reason. I've decided to enable it via a new ioctl with a fallthrough to `AVR_IOCTL_USB_RESET` rather than adding it to the latter to preserve backwards compatibility for existing code relying on this ioctl.