### PR TITLE
Fix possible uart issue of loading UDR before TXEN

### DIFF
--- a/simavr/sim/avr_uart.c
+++ b/simavr/sim/avr_uart.c
@@ -303,6 +303,8 @@ avr_uart_udr_write(
 		if (avr_cycle_timer_status(avr, avr_uart_txc_raise, p) == 0)
 			avr_cycle_timer_register(avr, p->cycles_per_byte,
 					avr_uart_txc_raise, p); // start the tx pump
+	} else if (p->udrc.vector) {
+		avr_raise_interrupt(avr, &p->udrc);
 	}
 }
 


### PR DESCRIPTION
Found program that loaded data in UDR before TXEN which resulted in locking up.
Even after TXEN, the program locked up waiting for UDR to clear, which never happens.

Dont know the correct hardware behavior... However, this resolves the issue for me.