### PR TITLE
Add support for non-auto release to button

### DIFF
--- a/examples/parts/button.c
+++ b/examples/parts/button.c
@@ -1,12 +1,12 @@
 /*
 	button.c
 
-	This defines a sample for a very simple "peripheral" 
+	This defines a sample for a very simple "peripheral"
 	that can talk to an AVR core.
 	It is in fact a bit more involved than strictly necessary,
 	but is made to demonstrante a few useful features that are
 	easy to use.
-	
+
 	Copyright 2008, 2009 Michel Pollet <buserror@gmail.com>
 
  	This file is part of simavr.
@@ -43,7 +43,18 @@ button_auto_release(
 }
 
 /*
- * button press. set the "pin" to zerok and register a timer
+ * button release. set the "pin" to one
+ */
+void
+button_release(
+		button_t * b)
+{
+	avr_cycle_timer_cancel(b->avr, button_auto_release, b);
+	avr_raise_irq(b->irq + IRQ_BUTTON_OUT, 1); // release
+}
+
+/*
+ * button press. set the "pin" to zero and optionally register a timer
  * that will reset it in a few usecs
  */
 void
@@ -52,9 +63,11 @@ button_press(
 		uint32_t duration_usec)
 {
 	avr_cycle_timer_cancel(b->avr, button_auto_release, b);
-	avr_raise_irq(b->irq + IRQ_BUTTON_OUT, 0);// press
-	// register the auto-release
-	avr_cycle_timer_register_usec(b->avr, duration_usec, button_auto_release, b);
+	avr_raise_irq(b->irq + IRQ_BUTTON_OUT, 0); // press
+	if (duration_usec) {
+		// register the auto-release
+		avr_cycle_timer_register_usec(b->avr, duration_usec, button_auto_release, b);
+	}
 }
 
 void
@@ -66,4 +79,3 @@ button_init(
 	b->irq = avr_alloc_irq(&avr->irq_pool, 0, IRQ_BUTTON_COUNT, &name);
 	b->avr = avr;
 }
-

--- a/examples/parts/button.h
+++ b/examples/parts/button.h
@@ -1,12 +1,12 @@
 /*
 	button.h
 
-	This defines a sample for a very simple "peripheral" 
+	This defines a sample for a very simple "peripheral"
 	that can talk to an AVR core.
 	It is in fact a bit more involved than strictly necessary,
 	but is made to demonstrante a few useful features that are
 	easy to use.
-	
+
 	Copyright 2008, 2009 Michel Pollet <buserror@gmail.com>
 
  	This file is part of simavr.
@@ -51,5 +51,9 @@ void
 button_press(
 		button_t * b,
 		uint32_t duration_usec);
+
+void
+button_release(
+		button_t * b);
 
 #endif /* __BUTTON_H__*/


### PR DESCRIPTION
This allows better control of key press length, if needed.

To minimize negative effect on existng code, if the duration
argument of button_press is non-zero, functionality is kept as is
(i.e., using auto-release). If duration is set to zero, then button
will have to be explicitly released using a new API function,
button_release.

If simulation uses GLUT, it may make use of glutKeyboardUpFunc and
glutIgnoreKeyRepeat (in addition to glutKeyboardFunc found in
existing examples) to have more exact control over button presses
and releases.