### PR TITLE
Test-related maintenance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ before_install:
 - sudo apt-get install -qq libelf-dev gcc-avr avr-libc freeglut3-dev
 
 language: c
-script: make V=1
-
+script:
+- make V=1
+- make -C tests run_tests V=1

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,7 +1,0 @@
-test_atmega48_disabled_timer
-test_atmega48_enabled_timer
-test_atmega48_watchdog_test
-test_atmega644_adc_test
-test_atmega88_example
-test_atmega88_timer16
-test_atmega88_uart_echo

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,7 +2,7 @@
 # This makefile takes each "at*" file, extracts it's part name
 # And compiles it into an ELF binary.
 # It also disassembles it for debugging purposes.
-# 
+#
 # 	Copyright 2008-2012 Michel Pollet <buserror@gmail.com>
 #
 #	This file is part of simavr.
@@ -28,24 +28,20 @@ IPATH 		+= ${simavr}/simavr/sim
 
 tests_src	:= ${wildcard test_*.c}
 
-all: obj axf tests
+all: obj axf tst
 
 include ../Makefile.common
 
-tests		:= ${patsubst %.c, ${OBJ}/%.tst, ${tests_src}}
+tst: ${patsubst %.c, ${OBJ}/%.tst, ${tests_src}}
 
-tests:	${tests}
-	
 axf: ${sources:.c=.axf}
-	
+
 
 ${OBJ}/%.tst: tests.c %.c
-ifeq ($(V),1)
-	$(CC) -MMD ${CPPFLAGS} ${CFLAGS} ${LFLAGS} -o $@ ${patsubst %.h,, ${^}} $(LDFLAGS)
-else
+ifneq ($(E),)
 	@echo TST $@
-	@$(CC) -MMD ${CPPFLAGS} ${CFLAGS} ${LFLAGS} -o $@ ${patsubst %.h,, ${^}} $(LDFLAGS)
 endif
+	${E}$(CC) -MMD ${CPPFLAGS} ${CFLAGS} ${LFLAGS} -o $@ ${patsubst %.h,, ${^}} $(LDFLAGS)
 
 run_tests: all
 	@export LD_LIBRARY_PATH=${simavr}/simavr/${OBJ} ;\
@@ -58,7 +54,8 @@ run_tests: all
 			num_failed=$$(($$num_failed+1)) ;\
 	    fi ;\
 	done ;\
-	echo "Tests run: $$num_run  Successes: $$(($$num_run-$$num_failed))  Failures: $$num_failed"
+	echo "Tests run: $$num_run  Successes: $$(($$num_run-$$num_failed))  Failures: $$num_failed" ;\
+	exit $$num_failed
 
 clean: clean-${OBJ}
 	rm -f *.axf *.vcd


### PR DESCRIPTION
- Ensure that make reports an error if any of the tests fail
- Don't duplicate compilation commands only for the sake of
  verbosity control
- Simplify recipe for .tst files
- Drop outdated and unnecessary .gitignore from tests directory
- Add the execution of tests to Travis CI