### PR TITLE
Set udre flag when (re)enabling uart transmitter.

### DIFF
--- a/simavr/sim/avr_uart.c
+++ b/simavr/sim/avr_uart.c
@@ -405,6 +405,8 @@ avr_uart_write(
 	if (new_txen != txen) {
 		if (p->udrc.vector && !new_txen) {
 			avr_uart_clear_interrupt(avr, &p->udrc);
+		} else {
+			avr_regbit_set(avr, p->udrc.raised);
 		}
 	}
 }


### PR DESCRIPTION
	modified:   sim/avr_uart.c

Previously, disabling the uart transmitter cleared the udrc
	interrupt and cleared the udre (udrc.raised) flag.  Upon
	reenabling the transmitter, the udre flag is still clear
	signifying the buffer is full, thus waiting for the udr to
	clear via udre flag hangs.