### PR TITLE
#414, #376 - Fix TOV/ICR handling, SEI delay

### DIFF
--- a/simavr/sim/sim_core.h
+++ b/simavr/sim/sim_core.h
@@ -113,7 +113,7 @@ static inline void avr_sreg_set(avr_t * avr, uint8_t flag, uint8_t ival)
 	if (flag == S_I) {
 		if (ival) {
 			if (!avr->sreg[S_I])
-				avr->interrupt_state = -2;
+				avr->interrupt_state = -1;
 		} else
 			avr->interrupt_state = 0;
 	}


### PR DESCRIPTION
- Fixes TOV/ICR flags getting clobbered if not serviced explicitly by an interrupt vector (e.g. out-of-band TOV handling) (#414 and linked issue)

- Adjust SEI delay to 1 cycle based on confirmed verification against Klipper firmware on real hardware vs the simulator.  (See comments in #376 and discussion in https://github.com/vintagepc/MK404/issues/263)

- Fixes #414 
- Closes #376

