### PR TITLE
Expand the I/O table to support the ATmega2560

### DIFF
--- a/simavr/sim/sim_avr.h
+++ b/simavr/sim/sim_avr.h
@@ -66,7 +66,7 @@ enum {
 	R_SREG	= 32+0x3f,
 
 	// maximum number of IO registers, on normal AVRs
-	MAX_IOs	= 280,	// Bigger AVRs need more than 256-32 (mega1280)
+	MAX_IOs	= 480,	// Bigger AVRs need 512-32 (mega2560)
 };
 
 #define AVR_DATA_TO_IO(v) ((v) - 32)


### PR DESCRIPTION
I had simavr segfault on me by running `sts 0x01ff, r0` on a simulated ATmega2560. This turned out to be `_avr_set_r()` calling an invalid function pointer found past the end of the array `avr->io`.

This pull request fixes the issue by expanding the `avr->io` array in order to cover the full I/O space of the ATmega2560.