### PR TITLE
Travis-ci:added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch:
+  - amd64
+  - ppc64le
 before_install:
 - sudo apt-get update -qq
 - sudo apt-get install -qq libelf-dev gcc-avr avr-libc freeglut3-dev


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch on behalf of IBM . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/simavr/builds/208083651 . I believe it is ready for the final review and merge.
Please have a look on it.

Thanks !!