### PR TITLE
Link libsimavr.so with needed libraries.

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -215,7 +215,7 @@ endif
 		-Wl,--whole-archive,-soname,${basename ${notdir $@}}.1 \
 		${filter %.o %.a,$^} \
 		 -Wl,--no-whole-archive \
-		${filter-out -l%, $(LDFLAGS)} ${EXTRA_LDFLAGS}
+		${filter-out -lsimavr, $(LDFLAGS)} ${EXTRA_LDFLAGS}
 
 ${OBJ}/%.so: ${OBJ}/%.so.1
 	ln -sf ${notdir $<} $@


### PR DESCRIPTION
 That is the usual way and allows it to be easily loaded by dlopen().