### PR TITLE
Correct interrupt vector size for megaxx4 AVRs (sim_megax4.h).

### DIFF
--- a/simavr/cores/sim_megax4.h
+++ b/simavr/cores/sim_megax4.h
@@ -77,7 +77,7 @@ struct mcu_t {
 const struct mcu_t SIM_CORENAME = {
 	.core = {
 		.mmcu = SIM_MMCU,
-		DEFAULT_CORE(4),
+		DEFAULT_CORE(2),
 
 		.init = mx4_init,
 		.reset = mx4_reset,


### PR DESCRIPTION
The data sheet says 2.  This fixes issue #443.