### PR TITLE
Fix #446 - bug in multipart ihex

### DIFF
--- a/simavr/sim/sim_hex.c
+++ b/simavr/sim/sim_hex.c
@@ -132,7 +132,8 @@ read_ihex_chunks(
 			case 0: // normal data
 				addr = segment | (bline[1] << 8) | bline[2];
 				break;
-			case 1: // end of file
+			case 1: // end of file - reset segment
+				segment = 0;
 				continue;
 			case 2: // extended address 2 bytes
 				segment = ((bline[4] << 8) | bline[5]) << 4;


### PR DESCRIPTION
Per #446 - there is a minor bug with multipart hex files because the segment is not reset to 0 when an "end of file" marker is reached. This causes the first segment of the next file to get an incorrect base address, and incorrectly breaks it into multiple chunks as well. 

Closes #446 