### PR TITLE
Add size property to avr_symbol_t

### DIFF
--- a/simavr/sim/sim_avr.h
+++ b/simavr/sim/sim_avr.h
@@ -358,6 +358,7 @@ typedef struct avr_kind_t {
 // a symbol loaded from the .elf file
 typedef struct avr_symbol_t {
 	uint32_t	addr;
+	uint32_t	size;
 	const char  symbol[0];
 } avr_symbol_t;
 

--- a/simavr/sim/sim_elf.c
+++ b/simavr/sim/sim_elf.c
@@ -382,6 +382,7 @@ elf_read_firmware(
 					avr_symbol_t * s = malloc(sizeof(avr_symbol_t) + strlen(name) + 1);
 					strcpy((char*)s->symbol, name);
 					s->addr = sym.st_value;
+					s->size = sym.st_size;
 					if (!(firmware->symbolcount % 8))
 						firmware->symbol = realloc(
 							firmware->symbol,


### PR DESCRIPTION
Adding a size field makes it easier to extract and inspect sections from a given elf_firmware_t.