### PR TITLE
Fix macos build with versioned avr-gcc

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -66,7 +66,7 @@ ifeq (${shell uname}, Darwin)
   # That's for Homebrew libelf and avr-gcc support
   HOMEBREW_PREFIX ?= /usr/local
   ifeq (${shell test -d $(HOMEBREW_PREFIX)/Cellar && echo Exists}, Exists)
-   ifneq (${shell test -d $(HOMEBREW_PREFIX)/Cellar/avr-gcc/ && echo Exists}, Exists)
+   ifneq (${shell test -d $(HOMEBREW_PREFIX)/Cellar/avr-gcc* && echo Exists}, Exists)
     $(error Please install avr-gcc: brew tap osx-cross/homebrew-avr ; brew install avr-libc)
    endif
    ifneq (${shell test -d $(HOMEBREW_PREFIX)/Cellar/libelf/ && echo Exists}, Exists)


### PR DESCRIPTION
Versioned homebrew installations are postfixed with @ (e.g. avr-gcc@9). The current makefile doesn't recognise these intallations as avr-gcc, so this PR fixes that.