### PR TITLE
TWI: Don't wait to ACK on SLA+R

### DIFF
--- a/simavr/sim/avr_twi.c
+++ b/simavr/sim/avr_twi.c
@@ -319,7 +319,7 @@ avr_twi_write(
 
 			if (p->peer_addr & 1) { // read ?
 				p->state |= TWI_COND_READ;	// always allow read to start with
-				_avr_twi_delay_state(p, 9,
+				_avr_twi_delay_state(p, 0,
 						p->state & TWI_COND_ACK ?
 								TWI_MRX_ADR_ACK : TWI_MRX_ADR_NACK);
 			} else {


### PR DESCRIPTION
The current behaviour of the avr_twi module will wait 9 TWI cycles before ACKing an SLA+R, effectively treating SLA+R as a regular data read. This causes the value in TWSR to be inaccurate for 8 cycles after TWINT is cleared following a successful SLA+R.