### PR TITLE
I2c slave implementation

### DIFF
--- a/examples/board_i2cslave/Makefile
+++ b/examples/board_i2cslave/Makefile
@@ -1,0 +1,52 @@
+# 
+# 	Copyright 2008-2012 Michel Pollet <buserror@gmail.com>
+#
+#	This file is part of simavr.
+#
+#	simavr is free software: you can redistribute it and/or modify
+#	it under the terms of the GNU General Public License as published by
+#	the Free Software Foundation, either version 3 of the License, or
+#	(at your option) any later version.
+#
+#	simavr is distributed in the hope that it will be useful,
+#	but WITHOUT ANY WARRANTY; without even the implied warranty of
+#	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#	GNU General Public License for more details.
+#
+#	You should have received a copy of the GNU General Public License
+#	along with simavr.  If not, see <http://www.gnu.org/licenses/>.
+
+target=	i2ctest
+firm_src = ${wildcard at*${board}.c}
+firmware = ${firm_src:.c=.axf}
+simavr = ../..
+
+IPATH = .
+IPATH += ${simavr}/examples/shared
+IPATH += ${simavr}/examples/parts
+IPATH += ${simavr}/include
+IPATH += ${simavr}/simavr/sim
+
+VPATH = .
+VPATH += ${simavr}/examples/shared
+VPATH += ${simavr}/examples/parts
+
+
+all: obj ${firmware} ${target} 
+
+include ${simavr}/Makefile.common
+
+atmega1280_${target}.axf: atmega1280_${target}.c twimaster.c
+atmega1280_${target}.axf: ${simavr}/examples/shared/avr_twi_master.c
+atmega1280_${target}.axf: ${simavr}/examples/shared/avr_twi_master.h
+
+board = ${OBJ}/${target}.elf
+
+${board} : ${OBJ}/${target}.o
+${board} : ${OBJ}/i2c_eeprom.o
+
+${target}: ${board}
+	@echo $@ done
+
+clean: clean-${OBJ}
+	rm -rf *.hex *.a *.axf ${target} *.vcd .*.swo .*.swp .*.swm .*.swn

--- a/examples/board_i2cslave/README
+++ b/examples/board_i2cslave/README
@@ -1,0 +1,15 @@
+
+This contains a sample program to demonstrate the use of simavr
+using 'custom' code, and own "peripherals". It shows how it is
+possible to "hook" code to the AVR pins, and also how to make
+"peripherals" and also hook them up to AVR pins.
+
+This demo demonstrate how to write a i2c/twi "peripheral" and hook it to
+an AVR, and then run a firmware that behaves as a TWI "slave" to talk to it.
+
+The code uses a generic i2c "eeprom" were the AVR writes some bytes,
+then read them again. The AVR code is based on the Atmel reference
+implementation, with quite a few changes to make it more functional.
+
+Thid "board" doesn't use opengl, the eeprom will display what the
+transactions are.

--- a/examples/board_i2cslave/atmega328p_i2cslave.c
+++ b/examples/board_i2cslave/atmega328p_i2cslave.c
@@ -51,10 +51,7 @@ static const __flash char msg[] = "Hello AVR!";
 static char buffer[ 128 ];
 static int index;
 
-int main() {
-
-  memset(&buffer[0], 0xFF, sizeof(buffer));
-
+int twi_receive( char *buffer, size_t size ) {
   if (twi_getState() != TW_SR_SLA_ACK) {
     abort();
   }
@@ -72,7 +69,7 @@ int main() {
   uint8_t state;
   while( ( state = twi_getState() ) == TW_SR_DATA_ACK ) {
     buffer[index++] = TWDR;
-    if( ( index + 1 ) < sizeof( buffer ) ) {
+    if( ( index + 1 ) < size ) {
       twi_ack();
     }
     else {
@@ -83,6 +80,14 @@ int main() {
   if( state != TW_SR_STOP ) {
     abort();
   }
+  return start;
+}
+
+int main() {
+
+  memset(&buffer[0], 0xFF, sizeof(buffer));
+
+  int start = twi_receive( &buffer[0], sizeof(buffer) );
 
   for( int i = 0; i < sizeof( msg )-1; i++ ) {
     if( buffer[start+i] != msg[i] ) {

--- a/examples/board_i2cslave/atmega328p_i2cslave.c
+++ b/examples/board_i2cslave/atmega328p_i2cslave.c
@@ -86,7 +86,7 @@ int twi_receive( char *buffer, size_t size ) {
   return start;
 }
 
-void twi_send( char *buffer, size_t size ) {
+int twi_send( char *buffer, size_t size ) {
   if (twi_getState() != TW_SR_SLA_ACK) {
     abort();
   }
@@ -98,6 +98,7 @@ void twi_send( char *buffer, size_t size ) {
     abort();
   }
   index = TWDR;
+  int start = index;
   twi_ack();
 
   uint8_t state;
@@ -122,9 +123,12 @@ void twi_send( char *buffer, size_t size ) {
     }
   }
 
-  if( state != TW_ST_LAST_DATA ) {
+  if( state != TW_ST_DATA_NACK ) {
     abort();
   }
+
+  TWCR = (1 << TWEN) | (1 << TWINT) | (1 << TWEA) | (1 << TWSTO);
+  return start;
 }
 
 int main() {
@@ -139,7 +143,7 @@ int main() {
     }
   }
 
-  twi_send( &buffer[0], sizeof(buffer) );
+  start = twi_send( &buffer[0], sizeof(buffer) );
 
   cli();
   sleep_mode();

--- a/examples/board_i2cslave/atmega328p_i2cslave.c
+++ b/examples/board_i2cslave/atmega328p_i2cslave.c
@@ -1,0 +1,76 @@
+/*
+        atmega48_i2ctest.c
+
+        Copyright 2021 Sebastian Koschmieder <sep@seplog.org>
+
+        This file is part of simavr.
+
+        simavr is free software: you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+        the Free Software Foundation, either version 3 of the License, or
+        (at your option) any later version.
+
+        simavr is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+        GNU General Public License for more details.
+
+        You should have received a copy of the GNU General Public License
+        along with simavr.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <stdlib.h>
+
+#include <avr/interrupt.h>
+#include <avr/io.h>
+#include <avr/sleep.h>
+#include <util/twi.h>
+
+// for linker, emulator, and programmer's sake
+#include "avr_mcu_section.h"
+AVR_MCU(F_CPU, "atmega328p");
+
+#include <stdio.h>
+
+void __attribute__((section(".init8"), naked)) initTWI(void) {
+  TWAR = (0x42 << 1);
+  TWAMR = 0x7F << 1;
+  TWCR = (1 << TWEA) | (1 << TWEN);
+}
+
+int twi_getState(void) {
+  while ((TWCR & (1 << TWINT)) == 0)
+    ;
+  return TWSR & 0xF8;
+}
+
+static inline void twi_ack(void) { TWCR |= (1 << TWINT) | (1 << TWEA); }
+static inline void twi_nack(void) { TWCR |= (1 << TWINT); }
+
+int main() {
+  if (twi_getState() != TW_SR_SLA_ACK) {
+    abort();
+  }
+
+  twi_ack();
+  if (twi_getState() != TW_SR_DATA_ACK) {
+    abort();
+  }
+
+  if (TWDR != 'A') {
+    abort();
+  }
+
+  twi_ack();
+  if (twi_getState() != TW_SR_DATA_ACK) {
+    abort();
+  }
+
+  if (TWDR != 'B') {
+    abort();
+  }
+
+  twi_nack();
+
+  cli();
+  sleep_mode();
+}

--- a/examples/board_i2cslave/i2ctest.c
+++ b/examples/board_i2cslave/i2ctest.c
@@ -118,9 +118,15 @@ static void i2c_master_send_hook(struct avr_irq_t *irq, uint32_t value,
       }
     }
     else {
-      printf( "Send stop!\n" );
-      avr_raise_irq(p->irq + TWI_IRQ_INPUT, avr_twi_irq_msg( TWI_COND_STOP, p->selected, 0));
-      // avr_irq_unregister_notify(p->irq + TWI_IRQ_OUTPUT, i2c_master_send_hook, p);
+      if( msg_current(p)->mode == TWI_WRITE ) {
+        printf( "Send stop!\n" );
+        avr_raise_irq(p->irq + TWI_IRQ_INPUT, avr_twi_irq_msg( TWI_COND_STOP, p->selected, 0));
+      }
+      else {
+        printf( "Send NACK!\n" );
+        avr_raise_irq(p->irq + TWI_IRQ_INPUT,
+          avr_twi_irq_msg( TWI_COND_READ, p->selected, 0 ));
+      }
 
       p->selected = 0;
       msg_free(p);

--- a/examples/board_i2cslave/i2ctest.c
+++ b/examples/board_i2cslave/i2ctest.c
@@ -1,0 +1,141 @@
+/*
+        i2ctest.c
+
+        Copyright 2021 Sebastian Koschmieder <sep@seplog.org>
+
+        This file is part of simavr.
+
+        simavr is free software: you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+        the Free Software Foundation, either version 3 of the License, or
+        (at your option) any later version.
+
+        simavr is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+        GNU General Public License for more details.
+
+        You should have received a copy of the GNU General Public License
+        along with simavr.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "avr_twi.h"
+#include "i2c_eeprom.h"
+#include "sim_avr.h"
+#include "sim_elf.h"
+#include "sim_gdb.h"
+
+//---------------------------------------
+typedef struct {
+  avr_t *avr;
+  avr_irq_t *irq;
+  uint8_t selected;
+} i2c_master;
+
+static void i2c_master_in_hook(struct avr_irq_t *irq, uint32_t value,
+                               void *param) {
+  ((void)irq);
+
+  i2c_master *p = (i2c_master *)param;
+  avr_twi_msg_irq_t v;
+  v.u.v = value;
+
+  switch (v.u.twi.msg) {
+  case (TWI_COND_ACK | TWI_COND_ADDR):
+    avr_raise_irq(avr_io_getirq(p->avr, AVR_IOCTL_TWI_GETIRQ(0), TWI_IRQ_INPUT),
+                  avr_twi_irq_msg(TWI_COND_WRITE, p->selected, 'A'));
+    break;
+  case TWI_COND_ACK:
+    avr_raise_irq(avr_io_getirq(p->avr, AVR_IOCTL_TWI_GETIRQ(0), TWI_IRQ_INPUT),
+                  avr_twi_irq_msg(TWI_COND_WRITE, p->selected, 'B'));
+    break;
+  default:
+    avr_raise_irq(avr_io_getirq(p->avr, AVR_IOCTL_TWI_GETIRQ(0), TWI_IRQ_INPUT),
+                  avr_twi_irq_msg(TWI_COND_STOP, p->selected, 0));
+    p->selected = 0;
+    break;
+  }
+}
+
+static const char *_master_irq_names[2] = {
+    [TWI_IRQ_INPUT] = "8>master.out",
+    [TWI_IRQ_OUTPUT] = "32<master.in",
+};
+
+void i2c_master_init(avr_t *avr, i2c_master *p) {
+  p->avr = avr;
+  p->irq = avr_alloc_irq(&avr->irq_pool, 0, 2, _master_irq_names);
+  p->selected = 0;
+  avr_irq_register_notify(p->irq + TWI_IRQ_OUTPUT, i2c_master_in_hook, p);
+}
+
+void i2c_master_attach(avr_t *avr, i2c_master *p, uint32_t i2c_irq_base) {
+  avr_connect_irq(p->irq + TWI_IRQ_INPUT,
+                  avr_io_getirq(avr, i2c_irq_base, TWI_IRQ_INPUT));
+  avr_connect_irq(avr_io_getirq(avr, i2c_irq_base, TWI_IRQ_OUTPUT),
+                  p->irq + TWI_IRQ_OUTPUT);
+}
+//---------------------------------------
+
+avr_t *avr = NULL;
+
+int main(int argc, char *argv[]) {
+  elf_firmware_t f;
+  const char *fname = "atmega328p_i2cslave.axf";
+
+  printf("Firmware pathname is %s\n", fname);
+  elf_read_firmware(fname, &f);
+
+  printf("firmware %s f=%d mmcu=%s\n", fname, (int)f.frequency, f.mmcu);
+
+  avr = avr_make_mcu_by_name(f.mmcu);
+  if (!avr) {
+    fprintf(stderr, "%s: AVR '%s' not known\n", argv[0], f.mmcu);
+    exit(1);
+  }
+  avr_init(avr);
+  avr_load_firmware(avr, &f);
+
+  // even if not setup at startup, activate gdb if crashing
+  avr->gdb_port = 1234;
+  if (0) {
+    avr->state = cpu_Stopped;
+    avr_gdb_init(avr);
+  }
+
+  avr_flashaddr_t main_addr = 0;
+  for (int i = 0; i < f.symbolcount; i++) {
+    // if (strncmp(f.symbol[i]->symbol, "_avr_twi_simple_slave", 128) == 0) {
+    if (strncmp(f.symbol[i]->symbol, "main", 128) == 0) {
+      main_addr = f.symbol[i]->addr;
+      break;
+    }
+  }
+
+  i2c_master ma;
+  i2c_master_init(avr, &ma);
+  i2c_master_attach(avr, &ma, AVR_IOCTL_TWI_GETIRQ(0));
+
+  avr->log = 4;
+
+  int send = 0;
+
+  printf("\nDemo launching:\n");
+
+  int state = cpu_Running;
+  while ((state != cpu_Done) && (state != cpu_Crashed)) {
+    state = avr_run(avr);
+    if (!send && avr->pc == main_addr) {
+      ma.selected = 0x42;
+      avr_raise_irq(
+          avr_io_getirq(avr, AVR_IOCTL_TWI_GETIRQ(0), TWI_IRQ_INPUT),
+          avr_twi_irq_msg(TWI_COND_START | TWI_COND_ADDR | TWI_COND_WRITE,
+                          ma.selected, 1));
+      send = 1;
+    }
+  }
+}

--- a/examples/parts/i2c_master.c
+++ b/examples/parts/i2c_master.c
@@ -1,0 +1,159 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <simavr/avr_twi.h>
+#include <simavr/sim_avr.h>
+
+#include "i2c_master.h"
+
+static inline struct msg *msg_current( i2c_master *m ) {
+    return &m->msgs->msg[ m->current_msg ];
+}
+
+static inline struct msg *msg_preview( i2c_master *m ) {
+    return &m->msgs->msg[ m->current_msg + 1 ];
+}
+
+static inline int msg_hasNext( i2c_master *m ) {
+    return ( m->current_msg + 1 ) < m->msgs->nmsg;
+}
+
+static inline void msg_moveNext( i2c_master *m ) {
+    m->current_msg++;
+}
+
+static inline void msg_free( i2c_master *m ) {
+    free( m->msgs->msg );
+    m->msgs->msg = NULL;
+    free( m->msgs );
+    m->msgs = NULL;
+}
+
+static void i2c_master_send_hook( struct avr_irq_t *irq, uint32_t value, void *param ) {
+    ( ( void ) irq );
+
+    i2c_master *p = ( i2c_master * ) param;
+    avr_twi_msg_irq_t v;
+    v.u.v = value;
+
+    if( !p->selected ) {
+        return;
+    }
+
+    switch( v.u.twi.msg ) {
+        case( TWI_COND_ACK | TWI_COND_ADDR ):
+
+            if( p->index >= msg_current( p )->size ) {
+                if( msg_hasNext( p ) && msg_current( p )->mode == msg_preview( p )->mode ) {
+                    p->index = 0;
+                    msg_moveNext( p );
+                }
+                else if( msg_hasNext( p ) && msg_current( p )->mode != msg_preview( p )->mode ) {
+                    p->index = 0;
+                    msg_moveNext( p );
+                    if( p->verbose )
+                        printf( "Send start to 0x%02X\n", p->selected );
+                    avr_raise_irq( p->irq + TWI_IRQ_INPUT,
+                                   avr_twi_irq_msg( TWI_COND_START | TWI_COND_ADDR |
+                                                        ( msg_current( p )->mode == TWI_WRITE
+                                                              ? TWI_COND_WRITE
+                                                              : TWI_COND_READ ),
+                                                    p->selected, 1 ) );
+                    break;
+                }
+            }
+
+            if( p->index < msg_current( p )->size ) {
+                if( msg_current( p )->mode == TWI_WRITE ) {
+                    char c = msg_current( p )->buffer[ p->index++ ];
+                    if( p->verbose )
+                        printf( "Send Databyte: '%c' (0x%02X)\n", c, c );
+                    avr_raise_irq( p->irq + TWI_IRQ_INPUT,
+                                   avr_twi_irq_msg( msg_current( p )->mode == TWI_WRITE
+                                                        ? TWI_COND_WRITE
+                                                        : TWI_COND_READ,
+                                                    p->selected, c ) );
+                }
+            }
+            else {
+                if( msg_current( p )->mode == TWI_WRITE ) {
+                    if( p->verbose )
+                        printf( "Send stop!\n" );
+                    avr_raise_irq( p->irq + TWI_IRQ_INPUT,
+                                   avr_twi_irq_msg( TWI_COND_STOP, p->selected, 0 ) );
+                }
+                else {
+                    if( p->verbose )
+                        printf( "Send NACK!\n" );
+                    avr_raise_irq( p->irq + TWI_IRQ_INPUT,
+                                   avr_twi_irq_msg( TWI_COND_READ, p->selected, 0 ) );
+                }
+
+                p->selected = 0;
+                msg_free( p );
+            }
+            break;
+        case( TWI_COND_ACK | TWI_COND_READ ):
+        case( TWI_COND_ACK | TWI_COND_ADDR | TWI_COND_READ ):
+            msg_current( p )->buffer[ p->index++ ] = v.u.twi.data;
+            if( p->verbose )
+                printf( "Receive Databyte: '%c' (0x%02X)\n", v.u.twi.data, v.u.twi.data );
+            avr_raise_irq(
+                p->irq + TWI_IRQ_INPUT,
+                avr_twi_irq_msg( TWI_COND_READ |
+                                     ( p->index < msg_current( p )->size ? TWI_COND_ACK : 0 ),
+                                 p->selected, 1 ) );
+            break;
+        case TWI_COND_ACK: break;
+        default:
+            if( p->verbose )
+                printf( "Undefined state: 0x%02X (0x%08X)\n", v.u.twi.msg, value );
+            avr_raise_irq( p->irq + TWI_IRQ_INPUT,
+                           avr_twi_irq_msg( TWI_COND_STOP, p->selected, 0 ) );
+
+            p->selected = 0;
+            msg_free( p );
+            break;
+    }
+}
+
+static const char *_master_irq_names[ 2 ] = {
+    [TWI_IRQ_INPUT] = "8>master.out",
+    [TWI_IRQ_OUTPUT] = "32<master.in",
+};
+
+void i2c_master_init( avr_t *avr, i2c_master *p ) {
+    p->avr = avr;
+    p->irq = avr_alloc_irq( &avr->irq_pool, 0, 2, _master_irq_names );
+    p->selected = 0;
+}
+
+void i2c_master_attach( avr_t *avr, i2c_master *p, uint32_t i2c_irq_base ) {
+    avr_connect_irq( p->irq + TWI_IRQ_INPUT, avr_io_getirq( avr, i2c_irq_base, TWI_IRQ_INPUT ) );
+    avr_connect_irq( avr_io_getirq( avr, i2c_irq_base, TWI_IRQ_OUTPUT ), p->irq + TWI_IRQ_OUTPUT );
+
+    avr_irq_register_notify( p->irq + TWI_IRQ_OUTPUT, i2c_master_send_hook, p );
+}
+
+void twi_startTransmission( avr_t *avr, i2c_master *m, struct nmsg *msgs ) {
+    ( ( void ) avr );
+    m->current_msg = 0;
+    m->index = 0;
+    m->msgs = msgs;
+
+    if( !msg_hasNext( m ) ) {
+        return;
+    }
+
+    m->selected = msg_current( m )->address;
+    if( msg_current( m )->mode == TWI_WRITE ) {
+        // avr_irq_register_notify( m->irq + TWI_IRQ_OUTPUT, i2c_master_send_hook, m );
+    }
+
+    if( m->verbose )
+        printf( "Send start to 0x%02X\n", m->selected );
+    avr_raise_irq(
+        m->irq + TWI_IRQ_INPUT,
+        avr_twi_irq_msg( TWI_COND_START | TWI_COND_ADDR | TWI_COND_WRITE, m->selected, 1 ) );
+}

--- a/examples/parts/i2c_master.h
+++ b/examples/parts/i2c_master.h
@@ -1,0 +1,37 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <simavr/sim_avr.h>
+#include <simavr/sim_irq.h>
+
+#ifndef _TWI_MASTER_H_
+#define _TWI_MASTER_H_
+
+struct msg {
+    enum { TWI_WRITE, TWI_READ } mode;
+    uint8_t address;
+    char *buffer;
+    size_t size;
+};
+struct nmsg {
+    struct msg *msg;
+    int nmsg;
+};
+
+typedef struct {
+    avr_t *avr;
+    avr_irq_t *irq;
+    uint8_t selected;
+    struct nmsg *msgs;
+    int current_msg;
+    long unsigned int index;
+    int verbose;
+} i2c_master;
+
+extern void i2c_master_init( avr_t *, i2c_master * );
+
+extern void i2c_master_attach( avr_t *, i2c_master *, uint32_t );
+
+extern void twi_startTransmission( avr_t *, i2c_master *, struct nmsg * );
+
+#endif

--- a/simavr/sim/avr_twi.c
+++ b/simavr/sim/avr_twi.c
@@ -427,7 +427,7 @@ avr_twi_irq_input(
 	 	if (msg.u.twi.msg & TWI_COND_READ) {
 			avr->data[p->r_twdr] = 0;
 			_avr_twi_delay_state(p, 9, msg.u.twi.msg & TWI_COND_ACK ?
-						TWI_STX_DATA_ACK : TWI_STX_DATA_ACK_LAST_BYTE );
+						TWI_STX_DATA_ACK : TWI_STX_DATA_NACK );
 		}
 	} else {
 		// receive a data byte from a slave

--- a/simavr/sim/avr_twi.c
+++ b/simavr/sim/avr_twi.c
@@ -411,6 +411,21 @@ avr_twi_irq_input(
 
 	AVR_TRACE(avr, "%s %08x\n", __func__, value);
 
+	if (p->state & TWI_COND_SLAVE) {
+		if (msg.u.twi.msg & TWI_COND_WRITE) {
+			avr->data[p->r_twdr] = msg.u.twi.data;
+			_avr_twi_delay_state(p, 9, TWI_SRX_ADR_DATA_ACK );
+		}
+	} else {
+		// receive a data byte from a slave
+		if (msg.u.twi.msg & TWI_COND_READ) {
+#if AVR_TWI_DEBUG
+			AVR_TRACE(avr, "I2C received %02x\n", msg.u.twi.data);
+#endif
+			avr->data[p->r_twdr] = msg.u.twi.data;
+		}
+	}
+
 	// receiving an attempt at waking a slave
 	if (msg.u.twi.msg & TWI_COND_START) {
 		p->state = 0;
@@ -452,20 +467,6 @@ avr_twi_irq_input(
 			p->state |= TWI_COND_ACK;
 		else
 			p->state &= ~TWI_COND_ACK;
-	}
-	if (p->state & TWI_COND_SLAVE) {
-		if (msg.u.twi.msg & TWI_COND_WRITE) {
-			avr->data[p->r_twdr] = msg.u.twi.data;
-			_avr_twi_delay_state(p, 9, TWI_SRX_ADR_DATA_ACK );
-		}
-	} else {
-		// receive a data byte from a slave
-		if (msg.u.twi.msg & TWI_COND_READ) {
-#if AVR_TWI_DEBUG
-			AVR_TRACE(avr, "I2C received %02x\n", msg.u.twi.data);
-#endif
-			avr->data[p->r_twdr] = msg.u.twi.data;
-		}
 	}
 }
 


### PR DESCRIPTION
Hello,

I have implemented a small example for a twi slave on an AVR device.
While I implemented this, I have seen that there a some small bugs within the implementation of the sim_twi.

I think the first was, that the interrupt Flag is cleared while writing a 1 TWIINT register.
The second was some invalid states of the TWI.

I think I have corrected these and attach a very simple implementation of the avr twi slave.

Best regards and many thanks for that great simulator!
seplog