### PR TITLE
Reduce MT and MR TWI acks to 0 cycles

### DIFF
--- a/simavr/sim/avr_twi.c
+++ b/simavr/sim/avr_twi.c
@@ -319,7 +319,7 @@ avr_twi_write(
 
 			if (p->peer_addr & 1) { // read ?
 				p->state |= TWI_COND_READ;	// always allow read to start with
-				_avr_twi_delay_state(p, 9,
+				_avr_twi_delay_state(p, 0,
 						p->state & TWI_COND_ACK ?
 								TWI_MRX_ADR_ACK : TWI_MRX_ADR_NACK);
 			} else {
@@ -328,7 +328,7 @@ avr_twi_write(
 							p->state & TWI_COND_ACK ?
 									TWI_MTX_ADR_ACK : TWI_MTX_ADR_NACK);
 				}else{
-					_avr_twi_delay_state(p, 9,
+					_avr_twi_delay_state(p, 0,
 							p->state & TWI_COND_ACK ?
 									TWI_MTX_DATA_ACK : TWI_MTX_DATA_NACK);
 				}


### PR DESCRIPTION
The issue that this PR addresses is explained in https://github.com/buserror/simavr/issues/453.

This fix feels like a bit of a hack to me; I'm happy to commit some time to contribute a better solution if suggested, but I'd like to understand the original need for these delay cycles first. As mentioned in  https://github.com/buserror/simavr/issues/453 the use of delays here seems to me to be inconsistent with the documentation for the atmega32u4's TWI module, perhaps this differs for other megax MCUs?