### PR TITLE
Fix WDIE being wrongly cleared in Interrupt Mode

### DIFF
--- a/simavr/sim/avr_watchdog.c
+++ b/simavr/sim/avr_watchdog.c
@@ -182,7 +182,7 @@ static void avr_watchdog_irq_notify(
 	 * again when cleared (after servicing), value = 0
 	 */
 
-	if (!value && avr_regbit_get(avr, p->watchdog.raised)) {
+	if (!value && avr_regbit_get(avr, p->watchdog.raised) && avr_regbit_get(avr, p->wde)) {
 		avr_regbit_clear(avr, p->watchdog.enable);
 	}
 }


### PR DESCRIPTION
WDIE must be automatically cleared only in "Interrupt and System Reset Mode" (where it's used to transition to "System Reset Mode").

In other modes, watchdog interrupt must not clear WDIE.

Strictly speaking, the modified condition also clears it in "System Reset Mode" as well, but the system is reset on interrupt anyway, so it doesn't matter.

See #456