### PR TITLE
Gdb: add support for "load" and "info_registers" and fix bugs.

### DIFF
--- a/simavr/sim/sim_avr.c
+++ b/simavr/sim/sim_avr.c
@@ -179,6 +179,7 @@ avr_reset(
 			port->reset(port);
 		port = port->next;
 	}
+	avr->cycle = 0; // Prevent crash
 }
 
 void

--- a/simavr/sim/sim_avr.c
+++ b/simavr/sim/sim_avr.c
@@ -286,7 +286,7 @@ void
 avr_callback_run_gdb(
 		avr_t * avr)
 {
-	avr_gdb_processor(avr, avr->state == cpu_Stopped);
+	avr_gdb_processor(avr, avr->state == cpu_Stopped ? 50000 : 0);
 
 	if (avr->state == cpu_Stopped)
 		return ;
@@ -331,7 +331,6 @@ avr_callback_run_gdb(
 	// if we were stepping, use this state to inform remote gdb
 	if (step)
 		avr->state = cpu_StepDone;
-
 }
 
 /*

--- a/simavr/sim/sim_avr.h
+++ b/simavr/sim/sim_avr.h
@@ -152,6 +152,8 @@ typedef void (*avr_run_t)(
 #define AVR_FUSE_HIGH	1
 #define AVR_FUSE_EXT	2
 
+#define REG_NAME_COUNT (256 + 32)       // Size of reg_names table.
+
 /*
  * Main AVR instance. Some of these fields are set by the AVR "Core" definition files
  * the rest is runtime data (as little as possible)

--- a/simavr/sim/sim_core.c
+++ b/simavr/sim/sim_core.c
@@ -321,7 +321,7 @@ avr_flashaddr_t _avr_pop_addr(avr_t * avr)
 /*
  * "Pretty" register names
  */
-const char * reg_names[255] = {
+const char * reg_names[REG_NAME_COUNT] = {
 		[R_XH] = "XH", [R_XL] = "XL",
 		[R_YH] = "YH", [R_YL] = "YL",
 		[R_ZH] = "ZH", [R_ZL] = "ZL",
@@ -330,7 +330,7 @@ const char * reg_names[255] = {
 };
 
 
-const char * avr_regname(uint8_t reg)
+const char * avr_regname(unsigned int reg)
 {
 	if (!reg_names[reg]) {
 		char tt[16];

--- a/simavr/sim/sim_core.c
+++ b/simavr/sim/sim_core.c
@@ -164,7 +164,8 @@ uint8_t avr_core_watch_read(avr_t *avr, uint16_t addr)
 				"CORE: *** Wrapping read address "
 				"PC=%04x SP=%04x O=%04x Address %04x %% %04x --> %04x\n"
 				FONT_DEFAULT,
-				avr->pc, _avr_sp_get(avr), _avr_flash_read16le(avr, avr->pc), addr, (avr->ramend + 1), addr % (avr->ramend + 1));
+				avr->pc, _avr_sp_get(avr), _avr_flash_read16le(avr, avr->pc),
+				addr, (avr->ramend + 1), addr % (avr->ramend + 1));
 		addr = addr % (avr->ramend + 1);
 	}
 
@@ -938,12 +939,9 @@ run_one_again:
 				case 0x9598: { // BREAK -- 1001 0101 1001 1000
 					STATE("break\n");
 					if (avr->gdb) {
-						// if gdb is on, we break here as in here
-						// and we do so until gdb restores the instruction
-						// that was here before
-						avr->state = cpu_StepDone;
-						new_pc = avr->pc;
-						cycle = 0;
+						// if gdb is on, break here.
+						avr->state = cpu_Stopped;
+						avr_gdb_handle_break(avr);
 					}
 				}	break;
 				case 0x95a8: { // WDR -- Watchdog Reset -- 1001 0101 1010 1000

--- a/simavr/sim/sim_gdb.h
+++ b/simavr/sim/sim_gdb.h
@@ -46,6 +46,7 @@ int avr_gdb_processor(avr_t * avr, int sleep);
 
 // Called from sim_core.c
 void avr_gdb_handle_watchpoints(avr_t * g, uint16_t addr, enum avr_gdb_watch_type type);
+void avr_gdb_handle_break(avr_t *);
 
 #ifdef __cplusplus
 };

--- a/simavr/sim/sim_gdb.h
+++ b/simavr/sim/sim_gdb.h
@@ -34,7 +34,7 @@ enum avr_gdb_watch_type {
 
 	AVR_GDB_WATCH_WRITE  = 1 << 2,
 	AVR_GDB_WATCH_READ   = 1 << 3,
-	AVR_GDB_WATCH_ACCESS = AVR_GDB_WATCH_WRITE | AVR_GDB_WATCH_READ,
+	AVR_GDB_WATCH_ACCESS = 1 << 4
 };
 
 int avr_gdb_init(avr_t * avr);


### PR DESCRIPTION
Addition of load command fixes #371.  The "awatch" command now works and "break" instructions are useable without having to make gdb jump over them by hand.  General gdb behaviour is improved by not sending confusing stop reports.  Other bug fixes as described in the commit comments, including an equivalent to the fix in #480.