### PR TITLE
Fix #421 (Tiny13) and an error in PR #482

### DIFF
--- a/simavr/cores/sim_tiny13.c
+++ b/simavr/cores/sim_tiny13.c
@@ -55,6 +55,7 @@ static const struct mcu_t {
 		/*
 		 * tiny13 has no extended fuse byte, so can not use DEFAULT_CORE macro
 		 */
+		.ioend  = RAMSTART - 1,
 		.ramend = RAMEND,
 		.flashend = FLASHEND,
 		.e2end = E2END,

--- a/simavr/sim/sim_core.h
+++ b/simavr/sim/sim_core.h
@@ -53,7 +53,7 @@ int _avr_push_addr(avr_t * avr, avr_flashaddr_t addr);
 /*
  * Get a "pretty" register name
  */
-const char * avr_regname(uint8_t reg);
+const char * avr_regname(unsigned int reg);
 
 /*
  * DEBUG bits follow


### PR DESCRIPTION
Makes the tiny13 work again and fixes an error in #482: building with tracing enabled is currently broken (found while verifying #421 fix).