### PR TITLE
Correct output streams for logging output.

### DIFF
--- a/simavr/sim/sim_avr.c
+++ b/simavr/sim/sim_avr.c
@@ -447,7 +447,7 @@ std_logger(
 		va_list ap)
 {
 	if (!avr || avr->log >= level) {
-		vfprintf((level > LOG_ERROR) ?  stdout : stderr , format, ap);
+		vfprintf((level < LOG_ERROR) ?  stdout : stderr, format, ap);
 	}
 }
 


### PR DESCRIPTION
Firmware output to stdout and diagnostics to stderr seem correct.