### PR TITLE
Combined function for loading ELF or ihex firmware.

### DIFF
--- a/simavr/sim/sim_hex.c
+++ b/simavr/sim/sim_hex.c
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "sim_hex.h"
+#include "sim_elf.h"
 
 // friendly hex dump
 void hdump(const char *w, uint8_t *b, size_t l)
@@ -190,7 +191,79 @@ read_ihex_file(
 	return res;
 }
 
+/* Load a firmware file, ELF or HEX format, from filename, based at
+ * loadBase, returning the data in *fp ready for loading into
+ * the simulated MCU.  Progname is the current program name for error messages.
+ *
+ * Included here as it mostly specific to HEX files.
+ */
 
+void
+sim_setup_firmware(const char * filename, uint32_t loadBase,
+                   elf_firmware_t * fp, const char * progname)
+{
+	char * suffix = strrchr(filename, '.');
+
+	if (suffix && !strcasecmp(suffix, ".hex")) {
+		if (!(fp->mmcu[0] && fp->frequency > 0)) {
+			printf("MCU type and frequency are not set "
+					"when loading .hex file\n");
+		}
+		ihex_chunk_p chunk = NULL;
+		int cnt = read_ihex_chunks(filename, &chunk);
+		if (cnt <= 0) {
+			fprintf(stderr,
+					"%s: Unable to load IHEX file %s\n", progname, filename);
+			exit(1);
+		}
+		printf("Loaded %d section(s) of ihex\n", cnt);
+
+		for (int ci = 0; ci < cnt; ci++) {
+			if (chunk[ci].baseaddr < (1*1024*1024)) {
+				if (fp->flash) {
+					printf("Ignoring chunk %d, "
+						   "possible flash redefinition %08x, %d\n",
+						   ci, chunk[ci].baseaddr, chunk[ci].size);
+					free(chunk[ci].data);
+					chunk[ci].data = NULL;
+					continue;
+				}
+				fp->flash = chunk[ci].data;
+				fp->flashsize = chunk[ci].size;
+				fp->flashbase = chunk[ci].baseaddr;
+				printf("Load HEX flash %08x, %d at %08x\n",
+					   fp->flashbase, fp->flashsize, fp->flashbase);
+			} else if (chunk[ci].baseaddr >= AVR_SEGMENT_OFFSET_EEPROM ||
+					   (chunk[ci].baseaddr + loadBase) >=
+							AVR_SEGMENT_OFFSET_EEPROM) {
+				// eeprom!
+
+				if (fp->eeprom) {
+
+					// Converting ELF with .mmcu section will do this.
+
+					printf("Ignoring chunk %d, "
+						   "possible eeprom redefinition %08x, %d\n",
+						   ci, chunk[ci].baseaddr, chunk[ci].size);
+					free(chunk[ci].data);
+					chunk[ci].data = NULL;
+					continue;
+				}
+				fp->eeprom = chunk[ci].data;
+				fp->eesize = chunk[ci].size;
+				printf("Load HEX eeprom %08x, %d\n",
+					   chunk[ci].baseaddr, fp->eesize);
+			}
+		}
+                free(chunk);
+	} else {
+		if (elf_read_firmware(filename, fp) == -1) {
+			fprintf(stderr, "%s: Unable to load firmware from file %s\n",
+					progname, filename);
+			exit(1);
+		}
+	}
+}
 
 #ifdef IHEX_TEST
 // gcc -std=gnu99 -Isimavr/sim simavr/sim/sim_hex.c -o sim_hex -DIHEX_TEST -Dtest_main=main

--- a/simavr/sim/sim_hex.h
+++ b/simavr/sim/sim_hex.h
@@ -30,6 +30,17 @@
 extern "C" {
 #endif
 
+// Load a firmware file, ELF or HEX format, ready for use.
+
+struct elf_firmware_t;                          // Predeclaration ...
+
+void
+sim_setup_firmware(
+				   const char * filename,       // Firmware file
+				   uint32_t loadBase,           // Base of load region
+				   struct elf_firmware_t * fp,  // Data returned here
+				   const char * progname);      // For error messages.
+
 // parses a hex text string 'src' of at max 'maxlen' characters, decodes it into 'buffer'
 int
 read_hex_string(

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,7 +1,6 @@
 #
-# This makefile takes each "at*" file, extracts it's part name
-# And compiles it into an ELF binary.
-# It also disassembles it for debugging purposes.
+# This makefile takes each "at*" file, extracts its part name
+# and compiles it into an ELF binary.
 #
 # 	Copyright 2008-2012 Michel Pollet <buserror@gmail.com>
 #
@@ -28,7 +27,7 @@ IPATH 		+= ${simavr}/simavr/sim
 
 tests_src	:= ${wildcard test_*.c}
 
-all: obj axf tst
+all: obj axf hex tst
 
 include ../Makefile.common
 
@@ -36,6 +35,7 @@ tst: ${patsubst %.c, ${OBJ}/%.tst, ${tests_src}}
 
 axf: ${sources:.c=.axf}
 
+hex: atmega88_example.hex
 
 ${OBJ}/%.tst: tests.c %.c
 ifneq ($(E),)
@@ -58,4 +58,4 @@ run_tests: all
 	exit $$num_failed
 
 clean: clean-${OBJ}
-	rm -f *.axf *.vcd
+	rm -f *.axf *.hex *.vcd

--- a/tests/test_atmega88_hex.c
+++ b/tests/test_atmega88_hex.c
@@ -1,0 +1,23 @@
+
+#include <string.h>
+
+#include "tests.h"
+
+/* Modified version of test_atmega88_example.c that uses a .hex file. */
+
+int main(int argc, char **argv) {
+	tests_init(argc, argv);
+
+	elf_firmware_t fw = {0};
+	strncpy(fw.mmcu, "atmega88", sizeof fw.mmcu);
+	fw.frequency = 8 * 1000 * 1000;
+
+	static const char *expected =
+		"Read from eeprom 0xdeadbeef -- should be 0xdeadbeef\r\n"
+		"Read from eeprom 0xcafef00d -- should be 0xcafef00d\r\n";
+	tests_assert_uart_receive_fw(&fw, "atmega88_example.hex", 100000,
+								 expected, '0');
+
+	tests_success();
+	return 0;
+}

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -2,6 +2,7 @@
 #define __TESTS_H__
 
 #include "sim_avr.h"
+#include "sim_elf.h"
 
 enum tests_finish_reason {
 	LJR_CYCLE_TIMER = 1,
@@ -40,6 +41,11 @@ void tests_assert_register_receive_avr(avr_t         *avr,
                                        unsigned long  run_usec,
                                        const char    *expected,
                                        avr_io_addr_t  reg_addr);
+void tests_assert_uart_receive_fw(elf_firmware_t *fw,
+								  const char *firmware,
+								  unsigned long run_usec,
+								  const char *expected,
+								  char uart);
 
 void tests_assert_cycles_at_least(unsigned long n);
 void tests_assert_cycles_at_most(unsigned long n);


### PR DESCRIPTION
Pull the .hex loading code out of run_avr.c and make it available as
a function, sim_setup_firmware(), that also handles ELF firmware.
Add a test, test_atmega88_hex.c, and use the new function in other tests.

This replaces #466.