### PR TITLE
Fix segfault with ATMega16m1 UART simulation

### DIFF
--- a/simavr/sim/avr_uart.c
+++ b/simavr/sim/avr_uart.c
@@ -532,9 +532,11 @@ avr_uart_init(
 	// status bits
 	// monitor code that reads the rxc flag, and delay it a bit
 	avr_register_io_read(avr, p->rxc.raised.reg, avr_uart_status_read, p);
-    if (p->fe.reg)
-        if (p->fe.reg != p->rxc.raised.reg)
+    if (p->fe.reg) {
+        if (p->fe.reg != p->rxc.raised.reg) {
             avr_register_io_read(avr, p->fe.reg, avr_uart_status_read, p);
+        }
+    }
 
 	if (p->udrc.vector)
 		avr_register_io_write(avr, p->udrc.enable.reg, avr_uart_write, p);

--- a/simavr/sim/avr_uart.c
+++ b/simavr/sim/avr_uart.c
@@ -532,8 +532,9 @@ avr_uart_init(
 	// status bits
 	// monitor code that reads the rxc flag, and delay it a bit
 	avr_register_io_read(avr, p->rxc.raised.reg, avr_uart_status_read, p);
-	if (p->fe.reg != p->rxc.raised.reg)
-		avr_register_io_read(avr, p->fe.reg, avr_uart_status_read, p);
+    if (p->fe.reg)
+        if (p->fe.reg != p->rxc.raised.reg)
+            avr_register_io_read(avr, p->fe.reg, avr_uart_status_read, p);
 
 	if (p->udrc.vector)
 		avr_register_io_write(avr, p->udrc.enable.reg, avr_uart_write, p);


### PR DESCRIPTION
Previously, when accessing the `p->fe.reg` in `avr_uart.c` (in `avr_uart_init()`) for ATmega16m1, the system segfaulted.

In avr_register_io_read, we see the following lines:

```c
	avr_io_addr_t a = AVR_DATA_TO_IO(addr);
	if (avr->io[a].r.param || avr->io[a].r.c) {
```

`AVR_DATA_TO_IO` just subtracts `0x20` from `addr`. `addr` is passed in from `avr_uart_init` as `p->fe.reg`. But in ATmega16m1, `p->fe` is not initialized, so it is set to zero. When we subtract `0x20` from `0`, and then do `avr->io[a]`, we have an array-out-of-bounds error.

The following previously segfaulted, but no longer does:

```shell
./simavr/run_avr -m atmega16m1 -f 4000000 ~/path/to/binary.elf
```