### PR TITLE
simavr not working on Arduino FreeRTOS

### DIFF
--- a/FreeRTOSwatchdog.patch
+++ b/FreeRTOSwatchdog.patch
@@ -1,0 +1,13 @@
+--- simavr/sim/avr_watchdog.c.orig	2018-01-10 07:05:15.000000000 -0300
++++ simavr/sim/avr_watchdog.c	2022-08-20 11:12:26.038063000 -0300
+@@ -183,7 +183,10 @@
+ 	 */
+ 
+ 	if (!value && avr_regbit_get(avr, p->watchdog.raised)) {
+-		avr_regbit_clear(avr, p->watchdog.enable);
++		/* It seems to me once activated WD it should never auto disable...
++		 * Edilson Azevedo <ekazevedo@github.com>
++		 */
++		// avr_regbit_clear(avr, p->watchdog.enable);
+ 	}
+ }

--- a/README.FreeRTOSwatchdog
+++ b/README.FreeRTOSwatchdog
@@ -4,7 +4,7 @@ Facts:
   - Firmware loaded either on 'SimulIDE' or 'simavr' command line don't.
   - Command line 'simavr -f 16000000 -m atmega2560 -ti 12 MySketch.ino.mega.hex' shows
     "IRQ12 raising (enabled 1), IRQ12 calling, IRQ12 cleared" only once.
-  - FreeRTOS arranged to show "High Watermark" shows "Tick count: 1" an no progress.
+  - FreeRTOS arranged to show "High Watermark" displays "Tick count: 1" an no progress.
 
 It seems 'avr watchdog' is anabled and auto disabled.
 So, I "commented" a line in 'avr_watchdog.c' and 'MySketch.ino.mega.hex':

--- a/README.FreeRTOSwatchdog
+++ b/README.FreeRTOSwatchdog
@@ -9,7 +9,7 @@ Facts:
 It seems 'avr watchdog' is anabled and auto disabled.
 So, I "commented" a line in 'avr_watchdog.c' and 'MySketch.ino.mega.hex':
   - work fine in 'simavr' command line,
-  - worf fine in SimulIDE.
+  - work fine in SimulIDE.
 
 Edilson Azevedo
 <ekazevedo@github.com>

--- a/README.FreeRTOSwatchdog
+++ b/README.FreeRTOSwatchdog
@@ -1,0 +1,15 @@
+Firmware developed for Arduino FreeRTOS did not work on simulator.
+Facts:
+  - Firmware loaded on the real machine work fine.
+  - Firmware loaded either on 'SimulIDE' or 'simavr' command line don't.
+  - Command line 'simavr -f 16000000 -m atmega2560 -ti 12 MySketch.ino.mega.hex' shows
+    "IRQ12 raising (enabled 1), IRQ12 calling, IRQ12 cleared" only once.
+  - FreeRTOS arranged for show "High Watermark" shows "Tick count: 1" an no progress.
+
+It seems 'avr watchdog' is anabled and auto disabled.
+So, I "commented" a line in 'avr_watchdog.c' and 'MySketch.ino.mega.hex':
+  - work fine in 'simavr' command line,
+  - worf fine in SimulIDE.
+
+Edilson Azevedo
+<ekazevedo@github.com>

--- a/README.FreeRTOSwatchdog
+++ b/README.FreeRTOSwatchdog
@@ -4,7 +4,7 @@ Facts:
   - Firmware loaded either on 'SimulIDE' or 'simavr' command line don't.
   - Command line 'simavr -f 16000000 -m atmega2560 -ti 12 MySketch.ino.mega.hex' shows
     "IRQ12 raising (enabled 1), IRQ12 calling, IRQ12 cleared" only once.
-  - FreeRTOS arranged for show "High Watermark" shows "Tick count: 1" an no progress.
+  - FreeRTOS arranged to show "High Watermark" shows "Tick count: 1" an no progress.
 
 It seems 'avr watchdog' is anabled and auto disabled.
 So, I "commented" a line in 'avr_watchdog.c' and 'MySketch.ino.mega.hex':

--- a/README.FreeRTOSwatchdog
+++ b/README.FreeRTOSwatchdog
@@ -10,6 +10,7 @@ It seems 'avr watchdog' is anabled and auto disabled.
 So, I "commented" a line in 'avr_watchdog.c' and 'MySketch.ino.mega.hex':
   - work fine in 'simavr' command line,
   - work fine in SimulIDE.
+See attached patch.
 
 Edilson Azevedo
 <ekazevedo@github.com>

--- a/README.FreeRTOSwatchdog
+++ b/README.FreeRTOSwatchdog
@@ -10,7 +10,7 @@ It seems 'avr watchdog' is anabled and auto disabled.
 So, I "commented" a line in 'avr_watchdog.c' and 'MySketch.ino.mega.hex':
   - work fine in 'simavr' command line,
   - work fine in SimulIDE.
-See attached patch.
+See attached 'FreeRTOSwatchdog.patch'.
 
 Edilson Azevedo
 <ekazevedo@github.com>


### PR DESCRIPTION
A firmware running on a real Arduino Mega2560 did not run either on 'SimulIDE' or 'simavr'.
- command line  'simavr -f 16000000 -m atmega2560 -ti 12 MySketch.ino.mega.hex' told me:
  "IRQ12 raising (enabled 1), IRQ12 calling, IRQ12 cleared" only once and stop.
  FreeRTOS Tick count = 1, based on watchdog,  never increases.
- I "commented" a line supposed to stop watchdog interrupts after done and now everything is working fine.

Please, see my attached patch referring to line 186 of 'sim/avr_watchdog.c'.

My workaround may not be a solution but it points out to.
So, guys, more work! Please, feel free to implement the final code.

Edilson Azevedo
<ekazevedo@github.com>