### PR TITLE
Fix data race when rendering an LCD display

### DIFF
--- a/examples/board_hd44780/Makefile
+++ b/examples/board_hd44780/Makefile
@@ -33,9 +33,10 @@ LDFLAGS += -lpthread
 
 include ../Makefile.opengl
 
-all: obj atmega48_charlcd.axf ${target} 
+all: obj atmega48_charlcd.axf atmega48_fps_test.axf ${target} 
 
 atmega48_charlcd.axf: atmega48_charlcd.c
+atmega48_fps_test.axf: atmega48_fps_test.c
 
 include ${simavr}/Makefile.common
 

--- a/examples/board_hd44780/atmega48_fps_test.c
+++ b/examples/board_hd44780/atmega48_fps_test.c
@@ -1,0 +1,47 @@
+#undef F_CPU
+#define F_CPU 16000000
+
+#include <avr/io.h>
+
+#include "avr_mcu_section.h"
+AVR_MCU(F_CPU, "atmega48");
+
+#include "avr_hd44780.c"
+
+int main()
+{
+	hd44780_init();
+	/*
+	 * Clear the display.
+	 */
+	hd44780_outcmd(HD44780_CLR);
+	hd44780_wait_ready(1); // long wait
+
+	/*
+	 * Entry mode: auto-increment address counter, no display shift in
+	 * effect.
+	 */
+	hd44780_outcmd(HD44780_ENTMODE(1, 0));
+	hd44780_wait_ready(0);
+
+	/*
+	 * Enable display, activate non-blinking cursor.
+	 */
+	hd44780_outcmd(HD44780_DISPCTL(1, 1, 0));
+	hd44780_wait_ready(0);
+
+	uint16_t count = 0;
+	while (1)
+	{
+		uint16_t temp = count;
+		for (uint8_t i = 5; i > 0; i--)
+		{
+			hd44780_outcmd(HD44780_DDADDR(i - 1));
+			hd44780_wait_ready(0);
+			hd44780_outdata(temp % 10 + 48);
+			temp /= 10;
+			hd44780_wait_ready(0);
+		}
+		count++;
+	}
+}

--- a/examples/board_hd44780/charlcd.c
+++ b/examples/board_hd44780/charlcd.c
@@ -172,6 +172,8 @@ main(
 
 	hd44780_init(avr, &hd44780, 20, 4);
 
+	hd44780_setup_mutex_for_gl(&hd44780);
+
 	/* Connect Data Lines to Port B, 0-3 */
 	/* These are bidirectional too */
 	for (int i = 0; i < 4; i++) {

--- a/examples/board_hd44780/charlcd.c
+++ b/examples/board_hd44780/charlcd.c
@@ -146,11 +146,15 @@ main(
 		char *argv[])
 {
 	elf_firmware_t f = {{0}};
-	const char * fname = "atmega48_charlcd.axf";
+	const char *fname = argc > 1 ? argv[1] : "atmega48_charlcd.axf";
 //	char path[256];
 //	sprintf(path, "%s/%s", dirname(argv[0]), fname);
 //	printf("Firmware pathname is %s\n", path);
-	elf_read_firmware(fname, &f);
+	if (elf_read_firmware(fname, &f) == -1)
+	{
+		fprintf(stderr, "Unable to load firmware from file %s\n", fname);
+		exit(EXIT_FAILURE);
+	};
 
 	printf("firmware %s f=%d mmcu=%s\n", fname, (int) f.frequency, f.mmcu);
 

--- a/examples/parts/hd44780_glut.h
+++ b/examples/parts/hd44780_glut.h
@@ -24,6 +24,14 @@
 
 #include "hd44780.h"
 
+// This sets the change callbacks of the hd44780 to
+// lock and unlock the mutex of the internal display.
+void
+hd44780_setup_mutex_for_gl(hd44780_t *b);
+
+// Draws the contents of the LCD display.
+// You must call hd44780_gl_init() and
+// hd44780_setup_mutex_for_gl() first.
 void
 hd44780_gl_draw(
 		hd44780_t *b,


### PR DESCRIPTION
### Summary

The example code for the LCD display uses two threads: one for simulating the AVR chip, and one for OpenGL. The state of the LCD display is stored as some flags in a `uint16_t` variable. When the OpenGL thread modifies a flag, it may accidentally undo a simultaneous write operation in the AVR thread, causing malfunction of the display.

In this PR I add mutex support to the LCD chip simulation. The pthread library is only included in the OpenGL-related parts of the code, so it is still possible to compile the LCD simulation itself without the threading library.

The introduction of this mutex does not noticeably affect performance.

### The problem

The LCD display is stored in a struct `hd44780_t`. This struct has a 2 byte integer member which contains various bit flags. One flag is for the internal status: whether the chip is reading the first or second nibble of the current byte. The other flag id for rendering: whether the content of the LCD screen needs to be redrawn. Since the access to this variable is not guarded, the OpenGL thread, while clearing the redraw flag, can also overwrite the other flag if it is changed by the simulation thread at the same time. After this, the LCD chip will interpret the incoming nibbles in the wrong order.

**Reproduction:** The first commit of this PR adds a new LCD fps testing program to the examples. Check out this commit, build the project, and execute
```
cd /examples/board_hd44780/obj-x86_64-linux-gnu
./charlcd.elf ../atmega48_fps_test.axf > /dev/null
```
A counter starts counting on the LCD screen:
![lcd-error-fixed](https://user-images.githubusercontent.com/20600448/194229278-ff7f92ea-5646-430b-9409-17931db317bb.png)
After some time (less than a minute on my laptop), garbage data starts to appear:
![lcd-error](https://user-images.githubusercontent.com/20600448/194229248-7cdd3b61-4a32-469a-98e9-5f3806e854d6.png)

### Solution

I added a new global mutex to the LCD OpenGL utilities. The both the drawing thread and the AVR thread uses this. The `hd44780_t` struct got two new callback members, one for locking and one for unlocking. This callback mechanism allows to use the struct without mutexes, if not needed. Finally, I split the flags of the LCD into two groups: there is a group of internal flags, which are not protected by the mutex (these flags are not needed for drawing), and there is a protected group. This splitting results in less mutex locking.

I tested the performance of this solution with the fps testing program. Both the old and new code displayed about 260000 frames in 1:54 (for this test it is important to redirect the output to `/dev/null`, otherwise the simulation will slow down).

### Other possible ways to solve the problem

- Only read data in the OpenGL thread: this works, but adding mutex support to the LCD display makes other applications besides rendering possible. Also, reading memory that is currently written to is still a data race.
- Lock the whole AVR struct, execute some instructions, then unlock: this would also work, but it would introduce locking when not necessary. However, if there is a need for locking for some other reason (for example, forwarding key presses to the AVR thread), it may be a better option to use a single, global lock for everything. The current LCD simulator sometimes stops with a segmentation fault because of this, so a global lock will be needed in the future anyways.
- Use a callback in the OpenGL thread too: this would mean that the OpenGL code can be compiled without the pthread library. In my opinion this would make the code more difficult to understand. I do not think that requiring pthread is a big problem if OpenGL is used.
- Store a mutex directly in the `hd44780_t` struct: this would mean that either pthread is required for compiling this component, or that it is guarded by a preprocessor macro.