### PR TITLE
Fix step and next instructions in avr-gdb debugging

### DIFF
--- a/simavr/sim/sim_gdb.c
+++ b/simavr/sim/sim_gdb.c
@@ -932,7 +932,7 @@ avr_gdb_processor(
 		gdb_send_stop_status(g, 5, "hwbreak", NULL);
 		avr->state = cpu_Stopped;
 	} else if (avr->state == cpu_StepDone) {
-		gdb_send_quick_status(g, 0);
+		gdb_send_stop_status(g, 5, "hwbreak", NULL);
 		avr->state = cpu_Stopped;
 	}
 	// this also sleeps for a bit


### PR DESCRIPTION
### Summary

When debugging the compiled program with avr-gdb, the `next` and `step` instructions always step only one machine instruction instead of stepping to the next source line. When the simulator finished the gdb client's step request, it responds that the program halted because of "signal 0". If I replace this with "signal 5, hardware breakpoint", avr-gdb works as expected. This effectively simulates that stepping is implemented with an automatically managed hardware breakpoint.

### Current behavior and how to reproduce the issue

In [examples/board_timer_64led/timer_64led.c:270](https://github.com/buserror/simavr/blob/7003af00df0f89a38898896fe536c5f15ae4ef1a/examples/board_timer_64led/timer_64led.c#L270) enable debugging and uncomment the next line (set the CPU state to stopped).

Build the project and run the `./atmega168_timer_64led.axf` example. It should stop at the first instruction, waiting for a debugger to attach.

Launch avr-gdb, and set a breakpoint at `atmega168_timer_64led.c:460` then run the program to it, and execute `next`. The debugger will step into the function call, instead of jumping over it. You can also try that `step` instructions will only jump a machine instruction, not a source line. Expected output of avr-gdb:
```
GNU gdb (GDB) 8.1.0.20180409-git
Copyright (C) 2018 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "--host=x86_64-linux-gnu --target=avr".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
<http://www.gnu.org/software/gdb/documentation/>.
For help, type "help".
Type "apropos word" to search for commands related to "word".
(gdb) file ./examples/board_timer_64led/atmega168_timer_64led.axf 
Reading symbols from ./examples/board_timer_64led/atmega168_timer_64led.axf...done.
(gdb) target remote :1234
Remote debugging using :1234
0x00000000 in __vectors ()
(gdb) b atmega168_timer_64led.c:460
Breakpoint 1 at 0x616: file atmega168_timer_64led.c, line 460.
(gdb) c
Continuing.
Note: automatically using hardware breakpoints for read-only addresses.

Breakpoint 1, main () at atmega168_timer_64led.c:460
460             tick_init();
(gdb) next

Program stopped.
tick_init () at atmega168_timer_64led.c:96
96              ASSR |= (1 << AS2);
(gdb) step

Program stopped.
0x0000018a in tick_init () at atmega168_timer_64led.c:96
96              ASSR |= (1 << AS2);
(gdb) step

Program stopped.
0x0000018c in tick_init () at atmega168_timer_64led.c:96
96              ASSR |= (1 << AS2);
(gdb) 
```

### Fixed behavior

After this patch, the next and step instructions work as expected.

```
GNU gdb (GDB) 8.1.0.20180409-git
Copyright (C) 2018 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "--host=x86_64-linux-gnu --target=avr".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
<http://www.gnu.org/software/gdb/documentation/>.
For help, type "help".
Type "apropos word" to search for commands related to "word".
(gdb) file ./examples/board_timer_64led/atmega168_timer_64led.axf 
Reading symbols from ./examples/board_timer_64led/atmega168_timer_64led.axf...done.
(gdb) target remote :1234
Remote debugging using :1234
0x00000000 in __vectors ()
(gdb) b atmega168_timer_64led.c:460
Breakpoint 1 at 0x616: file atmega168_timer_64led.c, line 460.
(gdb) c
Continuing.
Note: automatically using hardware breakpoints for read-only addresses.

Breakpoint 1, main () at atmega168_timer_64led.c:460
460             tick_init();
(gdb) next
462             startShowHours(4 * TICK_SECOND);
(gdb) step
startShowHours (timeout=timeout@entry=16 '\020') at atmega168_timer_64led.c:252
252             if (timer[delay_DisplayChange].delay != TICK_TIMER_DISABLED)
(gdb) step
253                     tick_timer_reset(delay_DisplayChange, timeout);
(gdb) step
254             state = (state & ~0xf) | state_ShowHour;
(gdb)
```

### Possible further work

It may be a good idea to [update the code where the gdb server responds](https://github.com/buserror/simavr/blob/7003af00df0f89a38898896fe536c5f15ae4ef1a/simavr/sim/sim_gdb.c#L621) to `?` requests too, but it seems that the current changes are enough to make debugging work correctly.