### PR TITLE
Enable self-programming for attinyx5

### DIFF
--- a/simavr/cores/sim_tinyx5.c
+++ b/simavr/cores/sim_tinyx5.c
@@ -29,6 +29,7 @@ void tx5_init(struct avr_t * avr)
 	struct mcu_t * mcu = (struct mcu_t*)avr;
 
 	avr_eeprom_init(avr, &mcu->eeprom);
+	avr_flash_init(avr, &mcu->selfprog);
 	avr_watchdog_init(avr, &mcu->watchdog);
 	avr_extint_init(avr, &mcu->extint);
 	avr_ioport_init(avr, &mcu->portb);

--- a/simavr/cores/sim_tinyx5.h
+++ b/simavr/cores/sim_tinyx5.h
@@ -26,6 +26,7 @@
 
 #include "sim_core_declare.h"
 #include "avr_eeprom.h"
+#include "avr_flash.h"
 #include "avr_watchdog.h"
 #include "avr_extint.h"
 #include "avr_ioport.h"
@@ -43,6 +44,7 @@ struct mcu_t {
 	avr_t core;
 	avr_eeprom_t 	eeprom;
 	avr_watchdog_t	watchdog;
+	avr_flash_t 	selfprog;
 	avr_extint_t	extint;
 	avr_ioport_t	portb;
 	avr_acomp_t		acomp;
@@ -66,6 +68,15 @@ const struct mcu_t SIM_CORENAME = {
 
 		.init = tx5_init,
 		.reset = tx5_reset,
+	},
+	.selfprog = {
+		.flags = 0,
+		.r_spm = SPMCSR,
+		.spm_pagesize = SPM_PAGESIZE,
+		.selfprgen = AVR_IO_REGBIT(SPMCSR, SPMEN),
+		.pgers = AVR_IO_REGBIT(SPMCSR, PGERS),
+		.pgwrt = AVR_IO_REGBIT(SPMCSR, PGWRT),
+		.blbset = AVR_IO_REGBIT(SPMCSR, RFLB),
 	},
 	AVR_EEPROM_DECLARE(EE_RDY_vect),
 	AVR_WATCHDOG_DECLARE(WDTCR, WDT_vect),

--- a/tests/attiny85_spm_test.c
+++ b/tests/attiny85_spm_test.c
@@ -1,0 +1,77 @@
+/*
+	attiny85_spm_test.c
+
+	Copyright 2022 Peter Smith
+
+	Test that the tiny85 can write to a page in the program memory space, by writing some junk data and
+	reading it back
+
+	This file is part of simavr.
+
+	simavr is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	simavr is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with simavr.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <avr/io.h>
+#include <avr/interrupt.h>
+#include <avr/boot.h>
+#include <avr/pgmspace.h>
+#include <stdio.h>
+#include <avr/sleep.h>
+#include "avr_mcu_section.h"
+
+AVR_MCU(F_CPU, "attiny85");
+
+/* No UART in tiny85, so simply write to unimplemented register ISIDR. */
+static int uart_putchar(char c, FILE *stream) {
+  if (c == '\n')
+	uart_putchar('\r', stream);
+  USIDR = c;
+  return 0;
+}
+
+static FILE mystdout = FDEV_SETUP_STREAM(uart_putchar, NULL, _FDEV_SETUP_WRITE);
+
+int main(void)
+{
+	static const int page = 0x1000;
+	static const uint16_t w = 0x1234;
+
+	for (int i = 0; i < SPM_PAGESIZE; i+=2) {
+		boot_page_fill(page + i, w);    
+	}
+
+	boot_page_erase(page);
+	boot_spm_busy_wait(); 
+
+	boot_page_write(page);
+	boot_spm_busy_wait();
+
+	stdout = &mystdout;
+	printf("Wrote %d bytes to address %d\n", SPM_PAGESIZE, page);
+
+	for (int i = 0; i < SPM_PAGESIZE; i+=2) {
+		uint16_t read_address = page + i;
+		uint16_t word = pgm_read_word_near(read_address);
+
+		if (word != w) {
+			printf("Address: %d, Unexpected value: %d\n", read_address, word);
+			cli();
+			sleep_cpu();
+		}
+	}
+
+	printf("Check Pass");
+	cli();
+	sleep_cpu();
+}

--- a/tests/test_attiny85_spm.c
+++ b/tests/test_attiny85_spm.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "tests.h"
+
+int main(int argc, char **argv) {
+	static const char *expected = "Wrote 64 bytes to address 4096\r\nCheck Pass";
+	avr_t             *avr;
+
+	tests_init(argc, argv);
+	avr = tests_init_avr("attiny85_spm_test.axf");
+
+	tests_assert_register_receive_avr(avr, 100000, expected, (avr_io_addr_t)0x2f);
+	tests_success();
+	return 0;
+}


### PR DESCRIPTION
The ATtinyx5 MCUs are able to self-program.
There is no RWW section, and no SPM interrupt on these chips