### PR TITLE
reverse patch from d2aaebd

### DIFF
--- a/simavr/sim/avr_ioport.c
+++ b/simavr/sim/avr_ioport.c
@@ -158,6 +158,11 @@ avr_ioport_irq_notify(
 	value &= 0xff;
 	uint8_t mask = 1 << irq->irq;
 	uint8_t ddr = avr->data[p->r_ddr];
+	// Set the real PIN bit. Ignore DDR as it's masked when read.
+
+	avr->data[p->r_pin] &= ~mask;
+	if (value)
+		avr->data[p->r_pin] |= mask;
 
 	if (output) {
 		if ((mask & ddr) == 0)


### PR DESCRIPTION
This patch reverses part of d2aaebd. If this reverse patch is not applied, then the library [FastAccelStepper](https://github.com/gin66/FastAccelStepper) stops working on simavr. As FastAccelStepper works on the real device, simavr's behavior seems to be not correct and maybe that reverse patch is a fix.

