### PR TITLE
flash+eeprom: fix ioctl handling

### DIFF
--- a/simavr/sim/avr_eeprom.c
+++ b/simavr/sim/avr_eeprom.c
@@ -115,6 +115,7 @@ avr_eeprom_ioctl(
 			memcpy(p->eeprom + desc->offset, desc->ee, desc->size);
 			AVR_LOG(port->avr, LOG_TRACE, "EEPROM: %s: AVR_IOCTL_EEPROM_SET Loaded %d at offset %d\n",
 					__FUNCTION__, desc->size, desc->offset);
+			res = 0;
 		}	break;
 		case AVR_IOCTL_EEPROM_GET: {
 			avr_eeprom_desc_t * desc = (avr_eeprom_desc_t*)io_param;
@@ -127,6 +128,7 @@ avr_eeprom_ioctl(
 				memcpy(desc->ee, p->eeprom + desc->offset, desc->size);
 			else	// allow to get access to the read data, for gdb support
 				desc->ee = p->eeprom + desc->offset;
+			res = 0;
 		}	break;
 	}
 

--- a/simavr/sim/avr_flash.c
+++ b/simavr/sim/avr_flash.c
@@ -72,6 +72,7 @@ avr_flash_ioctl(
 {
 	avr_flash_t * p = (avr_flash_t *)port;
 	avr_t * avr = p->io.avr;
+	int res = -1;
 
 	avr_flashaddr_t z = avr->data[R_ZL] | (avr->data[R_ZH] << 8);
 	if (avr->rampz)
@@ -85,24 +86,24 @@ avr_flash_ioctl(
 #endif
 	switch (ctl) {
 		case AVR_IOCTL_FLASH_LPM: {
-			uint8_t *res = io_param;
+			uint8_t *result = io_param;
 			if (avr_regbit_get(avr, p->selfprgen)) {
 				avr_cycle_timer_cancel(avr, avr_progen_clear, p);
 				if (avr_regbit_get(avr, p->blbset)) {
 					AVR_LOG(avr, LOG_TRACE, "FLASH: Reading fuse/lock byte %02x\n", z);
 					switch (z) {
-						case 0x0: *res = avr->fuse[0]; break; // LFuse
-						case 0x1: *res = avr->lockbits; break; // lock bits
-						case 0x2: *res = avr->fuse[2]; break; // EFuse
-						case 0x3: *res = avr->fuse[1]; break; // HFuse
+						case 0x0: *result = avr->fuse[0]; break; // LFuse
+						case 0x1: *result = avr->lockbits; break; // lock bits
+						case 0x2: *result = avr->fuse[2]; break; // EFuse
+						case 0x3: *result = avr->fuse[1]; break; // HFuse
 					}
 				} else if (avr_regbit_get(avr, p->sigrd)) {
 					AVR_LOG(avr, LOG_TRACE, "FLASH: Reading signature&serial byte %02x\n", z);
 					switch (z) {
-						case 0x00: *res = avr->signature[0]; break;
-						case 0x02: *res = avr->signature[1]; break;
-						case 0x04: *res = avr->signature[2]; break;
-						case 0x01: *res = 0x55; break;	// OSC Cal
+						case 0x00: *result = avr->signature[0]; break;
+						case 0x02: *result = avr->signature[1]; break;
+						case 0x04: *result = avr->signature[2]; break;
+						case 0x01: *result = 0x55; break;	// OSC Cal
 						/* serial# bytes are ordered bizarelly */
 						/* NOTE: Not all AVR that have sigrd have a
 						 * serial number, currenly we return one anyway */
@@ -111,11 +112,12 @@ avr_flash_ioctl(
 								1,0,3,2,5,4,0,6,7,8
 							};
 							z -= 0x0e;
-							*res = avr->serial[idx[z]]; break;
+							*result = avr->serial[idx[z]]; break;
 						}	break;
 					}
 				}
 			}
+			res = 0;
 		}	break;
 		case AVR_IOCTL_FLASH_SPM: {
 			uint16_t r01 = avr->data[0] | (avr->data[1] << 8);
@@ -150,10 +152,11 @@ avr_flash_ioctl(
 					}
 				}
 			}
+			res = 0;
 		}	break;
 	}
 	avr_regbit_clear(avr, p->selfprgen);
-	return 0;
+	return res;
 }
 
 static void

--- a/simavr/sim/sim_elf.c
+++ b/simavr/sim/sim_elf.c
@@ -174,7 +174,7 @@ avr_load_firmware(
 	if (firmware->eeprom && firmware->eesize) {
 		avr_eeprom_desc_t d = {
 				.ee = firmware->eeprom,
-				.offset = 0,
+				.offset = firmware->eeprombase,
 				.size = firmware->eesize
 		};
 		avr_ioctl(avr, AVR_IOCTL_EEPROM_SET, &d);
@@ -502,6 +502,7 @@ elf_read_firmware(
 			if (elf_handle_segment(fd, php, &firmware->eeprom, "EEPROM"))
 				continue;
 			firmware->eesize = php->p_filesz;
+			firmware->eeprombase = php->p_vaddr - 0x820000;
 		} else if (php->p_vaddr < 0x830000) {
 			/* Fuses. */
 

--- a/simavr/sim/sim_elf.h
+++ b/simavr/sim/sim_elf.h
@@ -71,6 +71,7 @@ typedef struct elf_firmware_t {
 	uint32_t 	datasize;
 	uint32_t 	bsssize;
 	// read the .eeprom section of the elf, too
+	uint32_t	eeprombase;
 	uint8_t * 	eeprom;
 	uint32_t 	eesize;
 	uint8_t *	fuse;

--- a/simavr/sim/sim_hex.c
+++ b/simavr/sim/sim_hex.c
@@ -251,6 +251,8 @@ sim_setup_firmware(const char * filename, uint32_t loadBase,
 				}
 				fp->eeprom = chunk[ci].data;
 				fp->eesize = chunk[ci].size;
+				fp->eeprombase = chunk[ci].baseaddr + loadBase -
+							AVR_SEGMENT_OFFSET_EEPROM;
 				printf("Load HEX eeprom %08x, %d\n",
 					   chunk[ci].baseaddr, fp->eesize);
 			}


### PR DESCRIPTION
The flash ioctl handler unconditionally reported the request as processed even when it was skipped. This lead to eeprom ioctl handler not getting called at all if it was registered later than the flash.

The eeprom ioctl handler reported the request as not processed even if it was, so fix that too while at it.

This bug resulted in the emulated firmware seeing blank EEPROM even when the contents was provided (as a section in ELF or as a separate HEX file) and r/w access via GDB not working.