### PR TITLE
simduino: remove GLUT dependency

### DIFF
--- a/examples/board_simduino/Makefile
+++ b/examples/board_simduino/Makefile
@@ -31,8 +31,6 @@ VPATH += ../parts
 
 LDFLAGS += -lpthread -lutil
 
-include ../Makefile.opengl
-
 all: obj ${firmware} ${target}
 
 include ${simavr}/Makefile.common

--- a/examples/board_simduino/simduino.c
+++ b/examples/board_simduino/simduino.c
@@ -27,11 +27,6 @@
 #include <stdio.h>
 #include <libgen.h>
 
-#if __APPLE__
-#include <GLUT/glut.h>
-#else
-#include <GL/glut.h>
-#endif
 #include <pthread.h>
 
 #include "sim_avr.h"


### PR DESCRIPTION
[examples/board_simduino](https://github.com/buserror/simavr/tree/26375838c521c60280ebdf205d17bb8b2e4fde47/examples/board_simduino) depends on OpenGL but does not actually use it. This small pull request removes the GLUT include/link. `git blame` shows that OpenGL code was included in simduino.c originally (https://github.com/buserror/simavr/commit/0a764c4ef24512959bcbb47eb905470a113fa856) and removed in commit https://github.com/buserror/simavr/commit/f6363b60812be10c6bf9fc9793dfee636a7d223b without removing the GLUT headers and linking.

I noticed this while working on a minimal Docker image for a text-only arduino simulator using simavr.