### PR TITLE
Add Github Action CI + Windows compile fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,217 @@
+name: Build Binaries
+on: [push, pull_request]
+
+jobs:
+  build-win64:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: git make mingw-w64-x86_64-toolchain mingw-w64-x86_64-libelf mingw-w64-x86_64-avr-toolchain mingw-w64-x86_64-freeglut
+      - name: CI-Build
+        run: |
+          echo 'Running in MSYS2!'
+          make build-simavr V=1
+          mkdir simavr_installed
+          make -k install DESTDIR=$(pwd)/simavr_installed/ || true
+          mv simavr_installed/bin/simavr simavr_installed/bin/simavr.exe
+          file simavr_installed/bin/*
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Windows 64-bit
+          path: simavr_installed
+  build-win32:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW32
+          update: true
+          install: git make mingw-w64-i686-toolchain mingw-w64-i686-libelf mingw-w64-i686-avr-toolchain mingw-w64-i686-freeglut
+      - name: CI-Build
+        run: |
+          make build-simavr V=1
+          mkdir simavr_installed
+          make -k install DESTDIR=$(pwd)/simavr_installed/ || true
+          mv simavr_installed/bin/simavr simavr_installed/bin/simavr.exe
+          file simavr_installed/bin/*
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Windows 32-bit
+          path: simavr_installed
+  build-lin64:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Dependenncies
+        run: sudo apt-get install -y build-essential git make gcc-avr avr-libc libelf-dev freeglut3-dev patchelf
+      - name: CI-Build
+        run: |
+          make build-simavr V=1 RELEASE=1
+          mkdir simavr_installed
+          make  install RELEASE=1 DESTDIR=$(pwd)/simavr_installed/
+          file simavr_installed/bin/*
+          patchelf --remove-needed ./libsimavr.so.1 simavr_installed/bin/simavr || true
+          patchelf --add-needed libsimavr.so.1 simavr_installed/bin/simavr
+          patchelf --set-rpath '$ORIGIN/../lib/' simavr_installed/bin/simavr
+          ldd simavr_installed/bin/*
+          simavr_installed/bin/simavr --list-cores || true
+      - name: Tar files
+        run: tar -cvf simavr.tar.gz -C simavr_installed .
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Linux 64-bit
+          path: simavr.tar.gz
+  build-lin32:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Dependenncies
+        run: | 
+          sudo dpkg --add-architecture i386
+          sudo apt-get update
+          sudo apt-get install -y libstdc++6:i386 libgcc1:i386 zlib1g:i386 libncurses5:i386 gcc-9:i386 binutils:i386 cpp-9:i386 libelf-dev:i386 freeglut3-dev:i386 gcc-avr avr-libc patchelf
+          ls -l /usr/bin/*gcc*
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 10
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 20
+          sudo update-alternatives --install /usr/bin/cc cc /usr/bin/gcc 30
+          sudo update-alternatives --set cc /usr/bin/gcc
+      - name: CI-Build
+        run: |
+          make build-simavr V=1 RELEASE=1
+          mkdir simavr_installed
+          make  install RELEASE=1 DESTDIR=$(pwd)/simavr_installed/
+          file simavr_installed/bin
+          patchelf --remove-needed ./libsimavr.so.1 simavr_installed/bin/simavr || true
+          patchelf --add-needed libsimavr.so.1 simavr_installed/bin/simavr
+          patchelf --set-rpath '$ORIGIN/../lib/' simavr_installed/bin/simavr
+          ldd simavr_installed/bin/*
+          simavr_installed/bin/simavr --list-cores || true
+      - name: Tar files
+        run: tar -cvf simavr.tar.gz -C simavr_installed .
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Linux 32-bit
+          path: simavr.tar.gz
+  build-armv7l:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: pguyot/arm-runner-action@v2
+        id: build_image
+        with:
+          cpu: cortex-a7
+          base_image: raspios_lite:latest
+          copy_artifact_path: simavr.tar.gz
+          image_additional_mb: 1024
+          commands: |
+            df -h /
+            sudo apt-get install -y build-essential git make gcc-avr avr-libc libelf-dev freeglut3-dev patchelf file
+            make -j4 build-simavr V=1 RELEASE=1
+            mkdir simavr_installed
+            make -j4 install RELEASE=1 DESTDIR=$(pwd)/simavr_installed/
+            file simavr_installed/bin/*
+            patchelf --remove-needed ./libsimavr.so.1 simavr_installed/bin/simavr || true
+            patchelf --add-needed libsimavr.so.1 simavr_installed/bin/simavr
+            patchelf --set-rpath '$ORIGIN/../lib/' simavr_installed/bin/simavr
+            ldd simavr_installed/bin/*
+            simavr_installed/bin/simavr --list-cores || true
+            tar -cvf simavr.tar.gz -C simavr_installed .
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Linux ARMv7l
+          path: simavr.tar.gz
+  build-armv6l:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: pguyot/arm-runner-action@v2
+        id: build_image
+        with:
+          cpu: arm1176
+          base_image: raspios_lite:latest
+          copy_artifact_path: simavr.tar.gz
+          image_additional_mb: 1024
+          commands: |
+            df -h /
+            sudo apt-get install -y build-essential git make gcc-avr avr-libc libelf-dev freeglut3-dev patchelf file
+            make build-simavr V=1 RELEASE=1
+            mkdir simavr_installed
+            make install RELEASE=1 DESTDIR=$(pwd)/simavr_installed/
+            file simavr_installed/bin/*
+            patchelf --remove-needed ./libsimavr.so.1 simavr_installed/bin/simavr || true
+            patchelf --add-needed libsimavr.so.1 simavr_installed/bin/simavr
+            patchelf --set-rpath '$ORIGIN/../lib/' simavr_installed/bin/simavr
+            ldd simavr_installed/bin/*
+            simavr_installed/bin/simavr --list-cores || true
+            tar -cvf simavr.tar.gz -C simavr_installed .
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Linux ARMv6l
+          path: simavr.tar.gz
+  build-aarch64:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: pguyot/arm-runner-action@v2
+        id: build_image
+        with:
+          cpu: cortex-a53
+          base_image: raspios_lite_arm64:latest
+          copy_artifact_path: simavr.tar.gz
+          image_additional_mb: 1024
+          commands: |
+            df -h /
+            sudo apt-get install -y build-essential git make gcc-avr avr-libc libelf-dev freeglut3-dev patchelf file
+            make -j4 build-simavr V=1 RELEASE=1
+            mkdir simavr_installed
+            make -j4 install RELEASE=1 DESTDIR=$(pwd)/simavr_installed/
+            file simavr_installed/bin/*
+            patchelf --remove-needed ./libsimavr.so.1 simavr_installed/bin/simavr || true
+            patchelf --add-needed libsimavr.so.1 simavr_installed/bin/simavr
+            patchelf --set-rpath '$ORIGIN/../lib/' simavr_installed/bin/simavr
+            ldd simavr_installed/bin/*
+            simavr_installed/bin/simavr --list-cores || true
+            tar -cvf simavr.tar.gz -C simavr_installed .
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Linux AArch64
+          path: simavr.tar.gz
+  build-darwin-x64:
+    # this is currently macos-11, Big Sur
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Dependenncies
+        run: | 
+          brew install make libelf freeglut patchelf 
+          brew tap osx-cross/avr
+          brew install avr-gcc@5 avr-binutils
+          export PATH="/usr/local/opt/avr-gcc@5/bin:$PATH"
+      - name: CI-Build
+        run: |
+          avr-gcc --version || true
+          clang --version
+          export CFLAGS="-DGL_SILENCE_DEPRECATION"
+          make -j4 build-simavr V=1 RELEASE=1
+          mkdir simavr_installed
+          make -k -j4 install RELEASE=1 DESTDIR=$(pwd)/simavr_installed/ || true
+          file simavr_installed/bin/*
+          otool -L simavr_installed/bin/*
+          simavr_installed/bin/simavr --list-cores || true
+      - name: Tar files
+        run: tar -cvf simavr.tar.gz -C simavr_installed .
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Mac OS Intel 64-bit
+          path: simavr.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,9 @@ jobs:
       - name: CI-Build
         run: |
           echo 'Running in MSYS2!'
-          make build-simavr V=1
+          CFLAGS="-D_XOPEN_SOURCE=600" make build-simavr V=1
           mkdir simavr_installed
-          make -k install DESTDIR=$(pwd)/simavr_installed/ || true
+          CFLAGS="-D_XOPEN_SOURCE=600" make -k install DESTDIR=$(pwd)/simavr_installed/ || true
           mv simavr_installed/bin/simavr simavr_installed/bin/simavr.exe
           file simavr_installed/bin/*
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,18 +8,12 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW64
           update: true
-          install: git make mingw-w64-x86_64-toolchain mingw-w64-x86_64-libelf mingw-w64-x86_64-freeglut
-      - name: Install AVR toolchain
-        run: |
-           wget "https://github.com/ZakKemble/avr-gcc-build/releases/download/v14.1.0-1/avr-gcc-14.1.0-x86-windows.zip"
-           unzip avr-gcc-14.1.0-x86-windows.zip
-           ls -l
-           echo "$(pwd)/avr-gcc-14.1.0-x86-windows/avr-gcc-14.1.0-x86-windows/bin" >> $GITHUB_PATH
+          install: git make mingw-w64-x86_64-toolchain mingw-w64-x86_64-libelf mingw-w64-x86_64-avr-toolchain  mingw-w64-x86_64-freeglut
       - name: CI-Build
         run: |
           echo 'Running in MSYS2!'
@@ -28,7 +22,7 @@ jobs:
           CFLAGS="-D_XOPEN_SOURCE=600" make -k install DESTDIR=$(pwd)/simavr_installed/ || true
           mv simavr_installed/bin/simavr simavr_installed/bin/simavr.exe
           file simavr_installed/bin/*
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Windows 64-bit
           path: simavr_installed
@@ -38,12 +32,18 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW32
           update: true
-          install: git make mingw-w64-i686-toolchain mingw-w64-i686-libelf mingw-w64-i686-avr-toolchain mingw-w64-i686-freeglut
+          install: git make mingw-w64-i686-toolchain mingw-w64-i686-libelf mingw-w64-i686-freeglut unzip
+      - name: Install AVR toolchain
+        run: |
+          wget "https://github.com/ZakKemble/avr-gcc-build/releases/download/v14.1.0-1/avr-gcc-14.1.0-x86-windows.zip"
+          unzip avr-gcc-14.1.0-x86-windows.zip
+          ls -l
+          echo "$(pwd)/avr-gcc-14.1.0-x86-windows/avr-gcc-14.1.0-x86-windows/bin" >> $GITHUB_PATH  
       - name: CI-Build
         run: |
           make build-simavr V=1
@@ -51,14 +51,14 @@ jobs:
           make -k install DESTDIR=$(pwd)/simavr_installed/ || true
           mv simavr_installed/bin/simavr simavr_installed/bin/simavr.exe
           file simavr_installed/bin/*
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Windows 32-bit
           path: simavr_installed
   build-lin64:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install Dependenncies
         run: sudo apt-get install -y build-essential git make gcc-avr avr-libc libelf-dev freeglut3-dev patchelf
       - name: CI-Build
@@ -74,14 +74,14 @@ jobs:
           simavr_installed/bin/simavr --list-cores || true
       - name: Tar files
         run: tar -cvf simavr.tar.gz -C simavr_installed .
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Linux 64-bit
           path: simavr.tar.gz
   build-lin32:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install Dependenncies
         run: | 
           sudo dpkg --add-architecture i386
@@ -105,14 +105,14 @@ jobs:
           simavr_installed/bin/simavr --list-cores || true
       - name: Tar files
         run: tar -cvf simavr.tar.gz -C simavr_installed .
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Linux 32-bit
           path: simavr.tar.gz
   build-armv7l:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: pguyot/arm-runner-action@v2
         id: build_image
         with:
@@ -133,14 +133,14 @@ jobs:
             ldd simavr_installed/bin/*
             simavr_installed/bin/simavr --list-cores || true
             tar -cvf simavr.tar.gz -C simavr_installed .
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Linux ARMv7l
           path: simavr.tar.gz
   build-armv6l:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: pguyot/arm-runner-action@v2
         id: build_image
         with:
@@ -161,14 +161,14 @@ jobs:
             ldd simavr_installed/bin/*
             simavr_installed/bin/simavr --list-cores || true
             tar -cvf simavr.tar.gz -C simavr_installed .
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Linux ARMv6l
           path: simavr.tar.gz
   build-aarch64:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: pguyot/arm-runner-action@v2
         id: build_image
         with:
@@ -189,7 +189,7 @@ jobs:
             ldd simavr_installed/bin/*
             simavr_installed/bin/simavr --list-cores || true
             tar -cvf simavr.tar.gz -C simavr_installed .
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Linux AArch64
           path: simavr.tar.gz
@@ -197,10 +197,10 @@ jobs:
     # this is currently macos-11, Big Sur
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install Dependenncies
         run: | 
-          brew install make libelf freeglut patchelf 
+          HOMEBREW_NO_INSTALL_FROM_API=1 brew install make libelf freeglut patchelf 
           HOMEBREW_NO_INSTALL_FROM_API=1 brew tap osx-cross/avr
           HOMEBREW_NO_INSTALL_FROM_API=1 brew install avr-gcc@5 avr-binutils
           export PATH="/usr/local/opt/avr-gcc@5/bin:$PATH"
@@ -217,7 +217,7 @@ jobs:
           simavr_installed/bin/simavr --list-cores || true
       - name: Tar files
         run: tar -cvf simavr.tar.gz -C simavr_installed .
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Mac OS Intel 64-bit
           path: simavr.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,7 +196,7 @@ jobs:
         run: | 
           brew install make libelf freeglut patchelf 
           brew tap osx-cross/avr
-          brew install avr-gcc@5 avr-binutils
+          HOMEBREW_NO_INSTALL_FROM_API=1 brew install avr-gcc@5 avr-binutils
           export PATH="/usr/local/opt/avr-gcc@5/bin:$PATH"
       - name: CI-Build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,9 @@ jobs:
       - name: CI-Build
         run: |
           echo 'Running in MSYS2!'
-          CFLAGS="-D_XOPEN_SOURCE=600" make build-simavr V=1
+          make build-simavr V=1
           mkdir simavr_installed
-          CFLAGS="-D_XOPEN_SOURCE=600" make -k install DESTDIR=$(pwd)/simavr_installed/ || true
+          make -k install DESTDIR=$(pwd)/simavr_installed/ || true
           mv simavr_installed/bin/simavr simavr_installed/bin/simavr.exe
           file simavr_installed/bin/*
       - uses: actions/upload-artifact@v4
@@ -202,8 +202,8 @@ jobs:
         run: | 
           HOMEBREW_NO_INSTALL_FROM_API=1 brew install make libelf freeglut patchelf 
           HOMEBREW_NO_INSTALL_FROM_API=1 brew tap osx-cross/avr
-          HOMEBREW_NO_INSTALL_FROM_API=1 brew install avr-gcc@5 avr-binutils
-          export PATH="/usr/local/opt/avr-gcc@5/bin:$PATH"
+          HOMEBREW_NO_INSTALL_FROM_API=1 brew install avr-gcc@9 avr-binutils
+          export PATH="/usr/local/opt/avr-gcc@9/bin:$PATH"
       - name: CI-Build
         run: |
           avr-gcc --version || true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -195,7 +195,7 @@ jobs:
       - name: Install Dependenncies
         run: | 
           brew install make libelf freeglut patchelf 
-          brew tap osx-cross/avr
+          HOMEBREW_NO_INSTALL_FROM_API=1 brew tap osx-cross/avr
           HOMEBREW_NO_INSTALL_FROM_API=1 brew install avr-gcc@5 avr-binutils
           export PATH="/usr/local/opt/avr-gcc@5/bin:$PATH"
       - name: CI-Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,13 @@ jobs:
         with:
           msystem: MINGW64
           update: true
-          install: git make mingw-w64-x86_64-toolchain mingw-w64-x86_64-libelf mingw-w64-x86_64-avr-toolchain mingw-w64-x86_64-freeglut
+          install: git make mingw-w64-x86_64-toolchain mingw-w64-x86_64-libelf mingw-w64-x86_64-freeglut
+      - name: Install AVR toolchain
+        run: |
+           wget "https://github.com/ZakKemble/avr-gcc-build/releases/download/v14.1.0-1/avr-gcc-14.1.0-x86-windows.zip"
+           unzip avr-gcc-14.1.0-x86-windows.zip
+           ls -l
+           echo "$(pwd)/avr-gcc-14.1.0-x86-windows/avr-gcc-14.1.0-x86-windows/bin" >> $GITHUB_PATH
       - name: CI-Build
         run: |
           echo 'Running in MSYS2!'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,7 @@ jobs:
           wget "https://github.com/ZakKemble/avr-gcc-build/releases/download/v14.1.0-1/avr-gcc-14.1.0-x86-windows.zip"
           unzip avr-gcc-14.1.0-x86-windows.zip
           ls -l
+          rm avr-gcc-14.1.0-x86-windows.zip
           echo "$(pwd)/avr-gcc-14.1.0-x86-windows/avr-gcc-14.1.0-x86-windows/bin" >> $GITHUB_PATH  
       - name: CI-Build
         run: |

--- a/simavr/sim/sim_avr.c
+++ b/simavr/sim/sim_avr.c
@@ -109,7 +109,11 @@ avr_init(
 #endif
 	avr->data_names = calloc(avr->ioend + 1, sizeof (char *));
 	/* put "something" in the serial number */
+#ifdef _WIN32
+	uint32_t r = getpid() + (uint32_t) rand();
+#else
 	uint32_t r = getpid() + random();
+#endif
 	for (int i = 0; i < ARRAY_SIZE(avr->serial); i++)
 		avr->serial[i] = r >> (i * 3);
 	AVR_LOG(avr, LOG_TRACE, "%s init\n", avr->mmcu);


### PR DESCRIPTION
Successfully test-compiles for
* Windows 64-bit (using MSys2)
* Windows 32-bit (using MSys2)
* Linux x64
* Linux x86
* Linux ARM (ARMv6l, ARMv7l, AArch64, a.k.a, Raspbis)
* Mac OS 14 ([source](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners))

And uploads the binary packages for it. They were tested to run a firmware fine on Windows.

Includes a tiny compilation fix for Windows based builds which apparently don't have the `random()` function (only available on Unix-like systems), so uses `rand()` instead. Breakage introduced in https://github.com/buserror/simavr/commit/3bb6c1d455e0f3f374261917ceaea1fab40b53a9.

Please squash upon merge to not have 10 commits.

For the run logs, see e.g. https://github.com/maxgerhardt/simavr/actions/runs/9536475177/