### PR TITLE
#542 Fix comment in avr_ioport.h

### DIFF
--- a/simavr/sim/avr_ioport.h
+++ b/simavr/sim/avr_ioport.h
@@ -60,7 +60,7 @@ typedef struct avr_ioport_getirq_t {
  *
  * for (int i = 'A'; i <= 'F'; i++) {
  * 	avr_ioport_state_t state;
- * 	if (avr_ioctl(AVR_IOCTL_IOPORT_GETSTATE(i), &state) == 0)
+ * 	if (avr_ioctl(avr, AVR_IOCTL_IOPORT_GETSTATE(i), &state) == 0)
  * 		printf("PORT%c %02x DDR %02x PIN %02x\n",
  * 			state.name, state.port, state.ddr, state.pin);
  * }


### PR DESCRIPTION
In comment starting at line 58 of avr_ioport.h there was one missing parameter 'avr' in the avr_ioctl() call on line 63