### PR TITLE
bugfix: Fix Test VCD Output

### DIFF
--- a/simavr/sim/avr_uart.c
+++ b/simavr/sim/avr_uart.c
@@ -256,9 +256,7 @@ avr_uart_udr_write(
 {
 	avr_uart_t * p = (avr_uart_t *)param;
 
-	// The byte to be sent should NOT be written there,
-	// the value written could never be read back.
-	//avr_core_watch_write(avr, addr, v);
+	avr_core_watch_write(avr, addr, v);
 	if (avr->gdb) {
 		avr_gdb_handle_watchpoints(avr, addr, AVR_GDB_WATCH_WRITE);
 	}

--- a/simavr/sim/sim_core.c
+++ b/simavr/sim/sim_core.c
@@ -173,12 +173,13 @@ _avr_flash_read16le(
 	return(avr->flash[addr] | (avr->flash[addr + 1] << 8));
 }
 
-static inline void _call_register_irqs(avr_t * avr, uint16_t addr, uint8_t v)
+static inline void _call_register_irqs(avr_t * avr, uint16_t addr)
 {
 	if (addr > 31 && addr < 31 + MAX_IOs) {
 		avr_io_addr_t io = AVR_DATA_TO_IO(addr);
 
 		if (avr->io[io].irq) {
+			uint8_t v = avr->data[addr];
 			avr_raise_irq(avr->io[io].irq + AVR_IOMEM_IRQ_ALL, v);
 			for (int i = 0; i < 8; i++)
 				avr_raise_irq(avr->io[io].irq + i, (v >> i) & 1);
@@ -242,7 +243,7 @@ void avr_core_watch_write(avr_t *avr, uint16_t addr, uint8_t v)
 	}
 
 	avr->data[addr] = v;
-	_call_register_irqs(avr, addr, v);
+	_call_register_irqs(avr, addr);
 	_call_sram_irqs(avr, addr);
 }
 
@@ -262,7 +263,7 @@ uint8_t avr_core_watch_read(avr_t *avr, uint16_t addr)
 		avr_gdb_handle_watchpoints(avr, addr, AVR_GDB_WATCH_READ);
 	}
 
-//	_call_register_irqs(avr, addr, avr->data[addr]);
+//	_call_register_irqs(avr, addr);
 	return avr->data[addr];
 }
 
@@ -287,8 +288,13 @@ static inline void _avr_set_r(avr_t * avr, uint16_t r, uint8_t v)
 			avr->io[io].w.c(avr, r, v, avr->io[io].w.param);
 		} else {
 			avr->data[r] = v;
+			if (avr->io[io].irq) {
+				avr_raise_irq(avr->io[io].irq + AVR_IOMEM_IRQ_ALL, v);
+				for (int i = 0; i < 8; i++)
+					avr_raise_irq(avr->io[io].irq + i, (v >> i) & 1);
+			}
 		}
-        _call_register_irqs(avr, r, v);
+        // _call_register_irqs(avr, r); // else section above could then be removed ?
 		_call_sram_irqs(avr, r); // Only for io region
 	} else
 		avr->data[r] = v;


### PR DESCRIPTION
Support VCD dumps for IO registers with write handlers (#486), implements changes suggested by @jamesrwaugh

# Testing
Running these commands 
```bash
make
cd simavr
./run_avr ../tests/atmega88_example.axf
gtkwave gtkwave_trace.vcd
```

# Output
![image](https://github.com/user-attachments/assets/e047356c-e153-41bc-b1e8-0eddc8374c5a)

```bash
./run_avr ../tests/atmega88_example.axf 
Loaded 1722 bytes of Flash data at 0
Loaded 114 bytes of Flash data at 0x6ba
Read from eeprom 0xdeadbeef -- should be 0xdeadbeef..
Read from eeprom 0xcafef00d -- should be 0xcafef00d..
```