### PR TITLE
Fix erroneous coloring of stderr messages

### DIFF
--- a/simavr/sim/avr_uart.c
+++ b/simavr/sim/avr_uart.c
@@ -277,7 +277,7 @@ avr_uart_udr_write(
 		if (v == '\n' || p->stdio_len == maxsize) {
 			p->stdio_len = 0;
 			AVR_LOG(avr, LOG_OUTPUT,
-					FONT_GREEN "%s\n" FONT_DEFAULT, p->stdio_out);
+					FONT_GREEN "%s" FONT_DEFAULT "\n", p->stdio_out);
 		}
 	}
 	TRACE(printf("UDR%c(%02x) = %02x\n", p->name, addr, v);)

--- a/simavr/sim/sim_core.c
+++ b/simavr/sim/sim_core.c
@@ -136,7 +136,7 @@ void crash(avr_t* avr)
 
 	for (int i = OLD_PC_SIZE-1; i > 0; i--) {
 		int pci = (avr->trace_data->old_pci + i) & 0xf;
-		printf(FONT_RED "*** %04x: %-25s RESET -%d; sp %04x\n" FONT_DEFAULT,
+		printf(FONT_RED "*** %04x: %-25s RESET -%d; sp %04x" FONT_DEFAULT "\n",
                        avr->trace_data->old[pci].pc,
                        avr->trace_data->codeline ?
                            avr->trace_data->codeline[avr->trace_data->old[pci].pc>>1] :
@@ -220,8 +220,7 @@ void avr_core_watch_write(avr_t *avr, uint16_t addr, uint8_t v)
 	}
 	if (addr < 32) {
 		AVR_LOG(avr, LOG_ERROR, FONT_RED
-				"CORE: *** Invalid write address PC=%04x SP=%04x O=%04x Address %04x=%02x low registers\n"
-				FONT_DEFAULT,
+				"CORE: *** Invalid write address PC=%04x SP=%04x O=%04x Address %04x=%02x low registers" FONT_DEFAULT "\n",
 				avr->pc, _avr_sp_get(avr), _avr_flash_read16le(avr, avr->pc), addr, v);
 		crash(avr);
 	}
@@ -233,7 +232,7 @@ void avr_core_watch_write(avr_t *avr, uint16_t addr, uint8_t v)
 	 */
 	if (avr->trace_data->stack_frame_index > 1 && addr > avr->trace_data->stack_frame[avr->trace_data->stack_frame_index-2].sp) {
 		printf( FONT_RED "%04x : munching stack "
-				"SP %04x, A=%04x <= %02x\n" FONT_DEFAULT,
+				"SP %04x, A=%04x <= %02x" FONT_DEFAULT "\n",
 				avr->pc, _avr_sp_get(avr), addr, v);
 	}
 #endif
@@ -252,8 +251,7 @@ uint8_t avr_core_watch_read(avr_t *avr, uint16_t addr)
 	if (addr > avr->ramend) {
 		AVR_LOG(avr, LOG_WARNING,
 				"CORE: *** Wrapping read address "
-				"PC=%04x SP=%04x O=%04x Address %04x %% %04x --> %04x\n"
-				FONT_DEFAULT,
+				"PC=%04x SP=%04x O=%04x Address %04x %% %04x --> %04x\n",
 				avr->pc, _avr_sp_get(avr), _avr_flash_read16le(avr, avr->pc),
 				addr, (avr->ramend + 1), addr % (avr->ramend + 1));
 		addr = addr % (avr->ramend + 1);
@@ -464,13 +462,13 @@ static void _avr_invalid_opcode(avr_t * avr)
 	}
 	avr->pc += 2;	// Step over.
 #if CONFIG_SIMAVR_TRACE
-	printf( FONT_RED "*** %04x: %-25s Invalid Opcode SP=%04x O=%04x \n" FONT_DEFAULT,
+	printf( FONT_RED "*** %04x: %-25s Invalid Opcode SP=%04x O=%04x" FONT_DEFAULT "\n",
                 avr->pc,
                 avr->trace_data->codeline[avr->pc>>1],
                 _avr_sp_get(avr),
                 _avr_flash_read16le(avr, avr->pc));
 #else
-	AVR_LOG(avr, LOG_ERROR, FONT_RED "CORE: *** %04x: Invalid Opcode SP=%04x O=%04x \n" FONT_DEFAULT,
+	AVR_LOG(avr, LOG_ERROR, FONT_RED "CORE: *** %04x: Invalid Opcode SP=%04x O=%04x" FONT_DEFAULT "\n",
 			avr->pc, _avr_sp_get(avr), _avr_flash_read16le(avr, avr->pc));
 #endif
 }

--- a/simavr/sim/sim_core.h
+++ b/simavr/sim/sim_core.h
@@ -80,7 +80,7 @@ void avr_dump_state(avr_t * avr);
 #define DUMP_STACK() \
 		for (int i = avr->trace_data->stack_frame_index; i; i--) {\
 			int pci = i-1;\
-			printf(FONT_RED "*** %04x: %-25s sp %04x\n" FONT_DEFAULT,\
+			printf(FONT_RED "*** %04x: %-25s sp %04x" FONT_DEFAULT "\n",\
 					avr->trace_data->stack_frame[pci].pc, \
 					avr->trace_data->codeline ? avr->trace_data->codeline[avr->trace_data->stack_frame[pci].pc>>1]->symbol : "unknown", \
 							avr->trace_data->stack_frame[pci].sp);\


### PR DESCRIPTION
Running a simple “Hello, World!” program with `run_avr` at verbosity level two prints the following to the terminal:

```shell
$ simavr/run_avr -v -v -f 16000000 -m atmega328p hello.elf
Loaded 216 bytes of Flash data at 0
Loaded 16 bytes of Flash data at 0xd8
UART: 0 configured to 0067 = 9615.3846 bps (x1), 8 data 1 stop
UART: Roughly 1144 usec per byte
Hello, World!..
simavr: sleeping with interrupts off, quitting gracefully
```

In the output above:
 * the line “Hello, World!..” is colored in green, as intended
 * the following line is also in green, and this is **not** intended.

This color glitch is caused by the line-buffering of `stdout`:

 * `run_avr` prints `FONT_GREEN "Hello, World!..\n" FONT_DEFAULT` to `stdout`
 * the libc sends `FONT_GREEN "Hello, World!..\n"` to the terminal, and keeps `FONT_DEFAULT` in its stdout output buffer
 * `run_avr` sends `"simavr: sleeping ... gracefully\n"` to `stderr`, which is unbuffered and thus the line goes straight to the terminal.

This pull request fixes this and similar color glitches by sending the `FONT_DEFAULT` ANSI escape code _before_ the newline. This plays nicely with the line-buffering of `stdout`.