### PR TITLE
Fix CI failure on AArch64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,7 +171,7 @@ jobs:
           name: Linux ARMv6l
           path: simavr.tar.gz
   build-aarch64:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: pguyot/arm-runner-action@v2


### PR DESCRIPTION
The [CI build on AArch64][ci] is failing on “No space left on device” errors. The failing step is defined as:

```yaml
uses: pguyot/arm-runner-action@v2
with:
  cpu: cortex-a53
  base_image: raspios_lite_arm64:latest
  image_additional_mb: 1024  # NOTE: because of this...
  commands: |
    df -h /                  # ...this should report at least 1 GiB free
    [...]
```

The `image_additional_mb` parameter has no effect: increasing the value does not fix the failure, and the `df` command reports only 143 MiB free.

It turns out pguyot/arm-runner-action attempted to resize the filesystem, but failed to do so. This is because the `raspios_lite_arm64:latest` image uses the quite new [“Orphan file” feature of ext4][orphan], which is not supported by the e2fsprogs 1.46.5 package shipped with the Ubuntu 22.04 runner image. This can be seen in the log:

```text
/dev/loop3p2 has unsupported feature(s): FEATURE_C12
e2fsck: Get a newer version of e2fsck!

rootfs: ********** WARNING: Filesystem still has errors **********

resize2fs 1.46.5 (30-Dec-2021)
resize2fs: Filesystem has unsupported feature(s) (/dev/loop3p2)
```

This pull request fixes the failure by upgrading the runner to Ubuntu 24.04. This Ubuntu release ships e2fsprogs 1.47.0, which is [the version introducing support for the “Orphan file” feature][e2fs].

[ci]: https://github.com/buserror/simavr/actions/runs/18200025079/job/51816354774
[orphan]: https://docs.kernel.org/filesystems/ext4/orphan.html
[e2fs]: https://e2fsprogs.sourceforge.net/e2fsprogs-release.html#1.47.0