### PR TITLE
Fix warning when compiling with -Wformat-security in tests/test_atmega328_jsys.c

### DIFF
--- a/tests/test_atmega328_jsys.c
+++ b/tests/test_atmega328_jsys.c
@@ -66,7 +66,7 @@ static void jsys_handler(struct avr_irq_t *irq, uint32_t value, void *param)
 			/* Print a string embedded in the flash. */
 
 			++pc;
-			printf((const char *)pc);	/* Can not use return value!. */
+			printf("%s", (const char *)pc);	/* Can not use return value!. */
 			pc += strlen((const char *)pc);
 			break;
 		}


### PR DESCRIPTION
Just noticed it wasn't building