### PR TITLE
Fix: avr_flash_t's tmppage was cleared to 0x00ff -> 0xffff in avr_flash_clear_temppage

### DIFF
--- a/simavr/sim/avr_flash.c
+++ b/simavr/sim/avr_flash.c
@@ -59,7 +59,7 @@ avr_flash_clear_temppage(
 		avr_flash_t *p)
 {
 	for (int i = 0; i < p->spm_pagesize / 2; i++) {
-		p->tmppage[i] = 0xff;
+		p->tmppage[i] = 0xffff;
 		p->tmppage_used[i] = 0;
 	}
 }


### PR DESCRIPTION
avr_flash_t's tmppage is of type uint16_t* and in avr_flash_clear_temppage it is reset to 0xff, which results to a pattern of 0x00ff00ff00ff... in the tmppage. This is supposed to be reset to 0xffff :)