### PR TITLE
Fix: Ignore lower z bits when erasing flash for page-alignment

### DIFF
--- a/simavr/sim/avr_flash.c
+++ b/simavr/sim/avr_flash.c
@@ -127,7 +127,7 @@ avr_flash_ioctl(
 				avr_cycle_timer_cancel(avr, avr_progen_clear, p);
 
 				if (avr_regbit_get(avr, p->pgers)) {
-					z &= ~1;
+					z &= ~(p->spm_pagesize - 1);
 					AVR_LOG(avr, LOG_TRACE, "FLASH: Erasing page %04x (%d)\n", (z / p->spm_pagesize), p->spm_pagesize);
 					for (int i = 0; i < p->spm_pagesize; i++)
 						avr->flash[z++] = 0xff;


### PR DESCRIPTION
Previously it was possible to erase the size of a page not page aligend. Documentation of atmega328 and atmega2560 states that for the erase operation the lower bits of z are ignored. (I guess it wouldn't make sense to not erase page aligned as well :)

I am sorry for opening so many PRs, I just only noticed the bug right after the last PR got merged.