### PR TITLE
changed rule for Mac and added Apple Silicon variant

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Build Binaries
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build-win64:
@@ -199,8 +199,8 @@ jobs:
           name: Linux AArch64
           path: simavr.tar.gz
   build-darwin-x64:
-    # this is currently macos-11, Big Sur
-    runs-on: macos-latest
+    # macos-latest is an ARM architecture runner, you need to use the suffix -intel
+    runs-on: macos-15-intel
     steps:
       - uses: actions/checkout@v4
       - name: Install Dependenncies
@@ -225,4 +225,31 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: Mac OS Intel 64-bit
+          path: simavr.tar.gz
+  build-darwin-arm64:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Dependenncies
+        run: | 
+          HOMEBREW_NO_INSTALL_FROM_API=1 brew install make libelf freeglut patchelf 
+          HOMEBREW_NO_INSTALL_FROM_API=1 brew tap osx-cross/avr
+          HOMEBREW_NO_INSTALL_FROM_API=1 brew install avr-gcc@9 avr-binutils
+          export PATH="/usr/local/opt/avr-gcc@9/bin:$PATH"
+      - name: CI-Build
+        run: |
+          avr-gcc --version || true
+          clang --version
+          export CFLAGS="-DGL_SILENCE_DEPRECATION"
+          make -j4 build-simavr V=1 RELEASE=1
+          mkdir simavr_installed
+          make -k -j4 install RELEASE=1 DESTDIR=$(pwd)/simavr_installed/ || true
+          file simavr_installed/bin/*
+          otool -L simavr_installed/bin/*
+          simavr_installed/bin/simavr --list-cores || true
+      - name: Tar files
+        run: tar -cvf simavr.tar.gz -C simavr_installed .
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Mac OS ARM 64-bit
           path: simavr.tar.gz


### PR DESCRIPTION
In the existing CI script, only one binary is produced for macOS, and it is claimed to be an Intel binary. However, it turns out that an Apple Silicon binary is produced because the runner is macos-latest, which, according to the documentation https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/choose-the-runner-for-a-job#standard-github-hosted-runners-for-public-repositories, is an arm64 runner. 

The corrected script now produces an ARM and an Intel binary for the Macs. Note that the latter one takes 1 hour (since it builds gcc from source, I believe).

