### PR TITLE
Fix UAF bug in read_ihex_chunks() when first chunk is reallocated

### DIFF
--- a/simavr/sim/sim_hex.c
+++ b/simavr/sim/sim_hex.c
@@ -172,8 +172,12 @@ read_ihex_chunks(
 			allocation += INCREMENT;
 			chunk = realloc(chunk, allocation + (sizeof *chunk - 1));
 
-			/* Update the pointer in the previous list element */
-			if ( backlink_p ) backlink_p->next = chunk;
+			/* Update the pointer in the previous list element or root */
+			if ( backlink_p ) {
+				backlink_p->next = chunk;
+			} else {
+				*chunks_p = chunk;
+			}
 
 			/* Refresh the pointer to the future chunk */
 			chunks_p = &chunk->next;


### PR DESCRIPTION
Commit e473c83 partially fixed UAF errors by introducing backlink_p to update the previous chunk's next pointer after realloc. However, when the first chunk is reallocated, backlink_p is NULL, so the root pointer (*chunks_p) never gets updated, leaving it pointing to freed memory.

This causes a use-after-free/double-free when read_ihex_file() later tries to free the chunk list.

Fix by updating *chunks_p directly when backlink_p is NULL (first chunk realloc case).

Valgrind confirmed this eliminates the UAF errors.