### PR TITLE
Add native Windows MSYS2 UCRT64 support

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,0 +1,38 @@
+name: Windows Build (MSYS2 UCRT64)
+
+on:
+  push:
+    branches: [ master, main ]
+  pull_request:
+    branches: [ master, main ]
+
+jobs:
+  build-windows:
+    name: Build libsimavr on Windows (MSYS2 UCRT64)
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up MSYS2 (UCRT64)
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: >-
+            mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-ucrt-x86_64-make
+            mingw-w64-ucrt-x86_64-libelf
+            mingw-w64-ucrt-x86_64-pkgconf
+
+      - name: Build libsimavr
+        shell: msys2 {0}
+        run: |
+          cd simavr
+          make
+
+      - name: Verify output artifact
+        shell: msys2 {0}
+        run: |
+          ls simavr/obj-*/libsimavr.a || (echo "Build artifact not found!" && exit 1)

--- a/Makefile.common
+++ b/Makefile.common
@@ -101,6 +101,7 @@ AVR		:= avr-
 IPATH		+= ${PREFIX}/include
 CFLAGS		+= -I${PREFIX}/include
 LDFLAGS		+= -L/lib -L/local/lib
+LDFLAGS		+= -lpthread
 CFLAGS 		+= -DNO_COLOR
 else
 CFLAGS 		+= -fPIC

--- a/simavr/sim/sim_avr.c
+++ b/simavr/sim/sim_avr.c
@@ -26,6 +26,13 @@
 #include <time.h>
 #include <unistd.h>
 #include <sys/time.h>
+/* Windows: CLOCK_MONOTONIC_RAW is Linux-specific. Suppress it so
+ * avr_get_time_stamp() uses the gettimeofday() path that works on MinGW. */
+#ifdef __MINGW32__
+#  ifdef CLOCK_MONOTONIC_RAW
+#    undef CLOCK_MONOTONIC_RAW
+#  endif
+#endif
 #include "sim_avr.h"
 #include "sim_core.h"
 #include "sim_time.h"

--- a/simavr/sim/sim_avr.h
+++ b/simavr/sim/sim_avr.h
@@ -26,6 +26,16 @@
 extern "C" {
 #endif
 
+/* Windows: ensure ssize_t is defined (MSYS2 UCRT64 provides sys/types.h but
+ * the _SSIZE_T_DEFINED guard may not be active in all MinGW compilation modes). */
+#ifdef __MINGW32__
+#  include <sys/types.h>
+#  ifndef _SSIZE_T_DEFINED
+#    define _SSIZE_T_DEFINED
+     typedef long ssize_t;
+#  endif
+#endif
+
 #ifndef __has_attribute
 	#define __has_attribute(x) 0
 #endif

--- a/simavr/sim/sim_gdb.c
+++ b/simavr/sim/sim_gdb.c
@@ -20,6 +20,15 @@
  */
 
 #include "sim_network.h"
+
+/* Windows: Winsock sockets must be closed with closesocket(), not close().
+ * sim_network.h already pulled in <winsock2.h> for __MINGW32__, so we only
+ * need a thin dispatch macro here. */
+#ifdef __MINGW32__
+#  define CLOSE_SOCKET(fd) closesocket((SOCKET)(uintptr_t)(unsigned int)(fd))
+#else
+#  define CLOSE_SOCKET(fd) close(fd)
+#endif
 #include <sys/time.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -765,7 +774,7 @@ gdb_handle_command(
 			if (avr->state = cpu_Stopped)
 				avr->state = cpu_Running;
 			gdb_send_reply(g, "OK");
-			close(g->s);
+			CLOSE_SOCKET(g->s);
 			g->s = -1;
 			break;
 #endif
@@ -826,7 +835,7 @@ gdb_network_handler(
 
 		if (r == 0) {
 			DBG(printf("%s connection closed\n", __FUNCTION__);)
-			close(g->s);
+			CLOSE_SOCKET(g->s);
 			gdb_watch_clear(&g->breakpoints);
 			gdb_watch_clear(&g->watchpoints);
 			g->avr->state = cpu_Running;	// resume
@@ -996,7 +1005,7 @@ avr_gdb_init(
 
 error:
 	if (g->listen >= 0)
-		close(g->listen);
+		CLOSE_SOCKET(g->listen);
 	free(g);
 
 	return -1;
@@ -1011,10 +1020,10 @@ avr_deinit_gdb(
 	avr->run = avr_callback_run_raw; // restore normal callbacks
 	avr->sleep = avr_callback_sleep_raw;
 	if (avr->gdb->listen != -1)
-		close(avr->gdb->listen);
+		CLOSE_SOCKET(avr->gdb->listen);
 	avr->gdb->listen = -1;
 	if (avr->gdb->s != -1)
-		close(avr->gdb->s);
+		CLOSE_SOCKET(avr->gdb->s);
 	avr->gdb->s = -1;
 	free(avr->gdb);
 	avr->gdb = NULL;


### PR DESCRIPTION
Fix compilation on Windows with MSYS2 UCRT64 / MinGW toolchain without breaking Linux or macOS builds. 

Changes:
sim_gdb.c: Add CLOSE_SOCKET() dispatch macro: closesocket() on Windows, close() on POSIX.
sim_avr.c: Suppress CLOCK_MONOTONIC_RAW under __MINGW32__ so avr_get_time_stamp() always takes the gettimeofday() code path.
sim_avr.h: Ensure ssize_t is defined on MinGW. 
Makefile.common: Add -lpthread to LDFLAGS in the existing Msys block so that winpthreads is linked on Windows.
.github/workflows/windows-build.yml: New CI workflow: builds libsimavr.a on every push/PR using MSYS2 UCRT64.