### PR TITLE
Fix read_ihex_chunks() once again

### DIFF
--- a/simavr/sim/sim_hex.c
+++ b/simavr/sim/sim_hex.c
@@ -84,7 +84,7 @@ read_ihex_chunks(
 		fw_chunk_t ** chunks_p )
 {
 	fw_chunk_t *chunk = *chunks_p;
-	fw_chunk_t *backlink_p = chunk;
+	fw_chunk_t **backlink_p = chunks_p; // should store the pointer where chunk address stored
 	int         len, allocation = 0;
 	uint8_t     chk = 0;
 	uint8_t     bline[272];
@@ -151,10 +151,10 @@ read_ihex_chunks(
 		}
 		if (!chunk || (chunk->size && addr != chunk->addr + chunk->size)) {
 			/* New chunk. */
-			backlink_p = chunk;
 			allocation = ALLOCATION - sizeof *chunk + 1;
 			chunk = (fw_chunk_t *)malloc(ALLOCATION);
 			*chunks_p = chunk;
+			backlink_p = chunks_p; // should store the pointer where chunk address stored
 			chunks_p = &chunk->next;
 			chunk->type = UNKNOWN;
 			chunk->addr = addr;
@@ -173,11 +173,7 @@ read_ihex_chunks(
 			chunk = realloc(chunk, allocation + (sizeof *chunk - 1));
 
 			/* Update the pointer in the previous list element or root */
-			if ( backlink_p ) {
-				backlink_p->next = chunk;
-			} else {
-				*chunks_p = chunk;
-			}
+			if ( backlink_p ) *backlink_p = chunk;
 
 			/* Refresh the pointer to the future chunk */
 			chunks_p = &chunk->next;


### PR DESCRIPTION
There were 2 attempts to fix issues around realloc() in read_ihex_chunks() a6fc4cc7 and e473c835 . And the issue is still there.