### PR TITLE
Adding USI two wire mode start & stop detection

### DIFF
--- a/simavr/sim/avr_usi.c
+++ b/simavr/sim/avr_usi.c
@@ -139,6 +139,21 @@ static void _avr_usi_connect_irqs(struct avr_t * avr, avr_usi_t * p, uint8_t new
 	}
 }
 
+static void _avr_usi_set_scl_hold(struct avr_t * avr, avr_usi_t * p, bool enable)
+{
+	avr_ioport_getirq_t req_ck = { .bit = p->pin_usck };
+	if (avr_ioctl(avr, AVR_IOCTL_IOPORT_GETIRQ_REGBIT, &req_ck) > 0) {
+		if (enable)
+			req_ck.irq[0]->flags |= IRQ_FLAG_STRONG;
+		else
+			req_ck.irq[0]->flags &= ~IRQ_FLAG_STRONG;
+	}
+	if (enable)
+		p->io.irq[USI_IRQ_USCK].flags |= IRQ_FLAG_STRONG;
+	else
+		p->io.irq[USI_IRQ_USCK].flags &= ~IRQ_FLAG_STRONG;
+}
+
 // -------------------------------------------------------------------------------------------------
 // USISR - status register
 // -------------------------------------------------------------------------------------------------
@@ -166,7 +181,7 @@ static void avr_usi_write_usisr(struct avr_t * avr, avr_io_addr_t addr, uint8_t 
 		v &= ~(1 << p->usi_start.raised.bit);
 		avr_clear_interrupt(avr, &p->usi_start);
 		if (avr_regbit_get(avr, p->usi_start.raised)) {
-			p->io.irq[USI_IRQ_USCK].flags &= ~IRQ_FLAG_USER;
+			_avr_usi_set_scl_hold(avr, p, false);
 		}
 	}
 
@@ -175,7 +190,7 @@ static void avr_usi_write_usisr(struct avr_t * avr, avr_io_addr_t addr, uint8_t 
 		v &= ~(1 << p->usi_ovf.raised.bit);
 		avr_clear_interrupt(avr, &p->usi_ovf);
 		if (avr_regbit_get(avr, p->usi_ovf.raised)) {
-			p->io.irq[USI_IRQ_USCK].flags &= ~IRQ_FLAG_USER;
+			_avr_usi_set_scl_hold(avr, p, false);
 		}
 	}
 
@@ -356,7 +371,7 @@ static void _avr_usi_usck_changed(struct avr_irq_t * irq, uint32_t value, void *
 
 	cs = avr_regbit_get(avr, p->usics);
 	if (cs < USI_CS_EXT_POS)
-		return;					// Clocked elsewhere.
+		return;	// Clocked elsewhere.
 
 	wm = avr_regbit_get(avr, p->usiwm);
 
@@ -375,10 +390,10 @@ static void _avr_usi_usck_changed(struct avr_irq_t * irq, uint32_t value, void *
 
 	if (wm >= USI_WM_TWOWIRE) {
 		/* Clock Stretching after Start Condition: Hold SCL low after
-			*  master pulls it low (till interrupt flag is cleared)
-			*/
+		 *  master pulls it low (till interrupt flag is cleared)
+		 */
 		if (down && avr_regbit_get(avr, p->usi_start.raised)) {
-			p->io.irq[USI_IRQ_USCK].flags |= IRQ_FLAG_USER;
+			_avr_usi_set_scl_hold(avr, p, true);
 		}
 	}
 
@@ -400,10 +415,10 @@ static void _avr_usi_usck_changed(struct avr_irq_t * irq, uint32_t value, void *
 
 	if (wm == USI_WM_TWOWIRE_HOLD) {
 		/* Clock Stretching after Overflow (start of ACK): Hold SCL low
-			*  after master pulls it low (till interrupt flag is cleared)
-			*/
+		 *  after master pulls it low (till interrupt flag is cleared)
+		 */
 		if (down && avr_regbit_get(avr, p->usi_ovf.raised)) {
-			p->io.irq[USI_IRQ_USCK].flags |= IRQ_FLAG_USER;
+			_avr_usi_set_scl_hold(avr, p, true);
 		}
 	}
 }

--- a/simavr/sim/avr_usi.c
+++ b/simavr/sim/avr_usi.c
@@ -38,12 +38,13 @@
 static void _avr_usi_clock_counter(struct avr_t * avr, avr_usi_t * p)
 {
 	uint8_t counter_val = avr->data[p->r_usisr] & 0xF;
+	uint8_t usisr = avr->data[p->r_usisr] & 0xf0;
 
 	counter_val++;
-	avr->data[p->r_usisr] &= 0xf0;
-	avr->data[p->r_usisr] |= (counter_val & 0x0f);
+	usisr |= (counter_val & 0x0f);
+	avr_core_watch_write(avr, p->r_usisr, usisr);
 
-	DBG(printf("USI ------------------- 	new value %d\n", counter_val));
+	DBG(printf("USI ------------------- 	new count value %d\n", counter_val));
 
 	if(counter_val > AVR_USI_COUNTER_MAX) {
 		if (p->r_usibr)
@@ -164,12 +165,18 @@ static void avr_usi_write_usisr(struct avr_t * avr, avr_io_addr_t addr, uint8_t 
 		DBG(printf("USI ------------------- 	clearing USISIF\n"));
 		v &= ~(1 << p->usi_start.raised.bit);
 		avr_clear_interrupt(avr, &p->usi_start);
+		if (avr_regbit_get(avr, p->usi_start.raised)) {
+			p->io.irq[USI_IRQ_USCK].flags &= ~IRQ_FLAG_USER;
+		}
 	}
 
 	if (v & (1 << p->usi_ovf.raised.bit)) {
 		DBG(printf("USI ------------------- 	clearing USIOIF\n"));
 		v &= ~(1 << p->usi_ovf.raised.bit);
 		avr_clear_interrupt(avr, &p->usi_ovf);
+		if (avr_regbit_get(avr, p->usi_ovf.raised)) {
+			p->io.irq[USI_IRQ_USCK].flags &= ~IRQ_FLAG_USER;
+		}
 	}
 
 	if (v & (1 << p->usipf.bit)) {
@@ -307,18 +314,44 @@ static void avr_usi_write_usidr(struct avr_t * avr, avr_io_addr_t addr, uint8_t 
 static void _avr_usi_di_changed(struct avr_irq_t * irq, uint32_t value, void * param)
 {
 	avr_usi_t * p = (avr_usi_t *)param;
+	avr_t     * avr = p->io.avr;
+	int         up, down;
 
 	DBG(printf("USI ------------------- DI changed to %d at cycle %llu\n",
 		value,
-		p->io.avr->cycle));
+		avr->cycle));
 	p->in_bit0 = value;
+
+	if (avr_regbit_get(avr, p->usiwm) >= USI_WM_TWOWIRE) {
+		//Start & Stop detection for two wire mode
+
+		if (!p->io.irq[USI_IRQ_USCK].value)
+			return; // SCL must be high at SDA change
+		avr_ioport_state_t iostate;
+		uint8_t port = p->port_ioctl & 0xFF;
+		if (avr_ioctl(avr, AVR_IOCTL_IOPORT_GETSTATE(port), &iostate) < 0)
+			return;
+		if (iostate.ddr & (1 << p->pin_di.bit))
+		 	return; // SDA must be in input mode
+
+		up = !irq->value && value;
+		down = irq->value && !value;
+
+		DBG(printf("USI ------------------- DI %s condition detected\n",
+			down ? "start" : up ? "stop" : "?"));
+		
+		if (down)
+			avr_raise_interrupt(avr, &p->usi_start);
+		else if (up)
+			avr_core_watch_write(avr, p->r_usisr, avr->data[p->r_usisr] | (1 << p->usipf.bit));
+	}
 }
 
 static void _avr_usi_usck_changed(struct avr_irq_t * irq, uint32_t value, void * param)
 {
 	avr_usi_t * p = (avr_usi_t *)param;
 	avr_t     * avr = p->io.avr;
-    int         up, down;
+	int         up, down;
 	uint8_t     wm, cs;
 
 	cs = avr_regbit_get(avr, p->usics);
@@ -340,8 +373,13 @@ static void _avr_usi_usck_changed(struct avr_irq_t * irq, uint32_t value, void *
 		up ? "rising" : down ? "falling" : "?",
 		avr->cycle));
 
-	if(wm == USI_WM_TWOWIRE || wm == USI_WM_TWOWIRE_HOLD) {
-		// TODO: tell the TWI CCU that something happened
+	if (wm >= USI_WM_TWOWIRE) {
+		/* Clock Stretching after Start Condition: Hold SCL low after
+			*  master pulls it low (till interrupt flag is cleared)
+			*/
+		if (down && avr_regbit_get(avr, p->usi_start.raised)) {
+			p->io.irq[USI_IRQ_USCK].flags |= IRQ_FLAG_USER;
+		}
 	}
 
 	/* External input clocks the counter on both edges.  Clock USIDR first,
@@ -358,6 +396,15 @@ static void _avr_usi_usck_changed(struct avr_irq_t * irq, uint32_t value, void *
 			_avr_usi_push_high_bit(p);
 		}
 		_avr_usi_clock_counter(avr, p);
+	}
+
+	if (wm == USI_WM_TWOWIRE_HOLD) {
+		/* Clock Stretching after Overflow (start of ACK): Hold SCL low
+			*  after master pulls it low (till interrupt flag is cleared)
+			*/
+		if (down && avr_regbit_get(avr, p->usi_ovf.raised)) {
+			p->io.irq[USI_IRQ_USCK].flags |= IRQ_FLAG_USER;
+		}
 	}
 }
 

--- a/simavr/sim/sim_irq.c
+++ b/simavr/sim/sim_irq.c
@@ -200,7 +200,9 @@ avr_raise_irq_float(
 		int floating)
 {
 	if (!irq)
-		return ;
+		return;
+	if (irq->flags & IRQ_FLAG_STRONG)
+		return;
 	uint32_t output = (irq->flags & IRQ_FLAG_NOT) ? !value : value;
 	// if value is the same but it's the first time, raise it anyway
 	if (irq->value == output &&

--- a/simavr/sim/sim_irq.h
+++ b/simavr/sim/sim_irq.h
@@ -57,7 +57,8 @@ enum {
 	IRQ_FLAG_ALLOC		= (1 << 2), //!< this irq structure was malloced via avr_alloc_irq
 	IRQ_FLAG_INIT		= (1 << 3), //!< this irq hasn't been used yet
 	IRQ_FLAG_FLOATING	= (1 << 4), //!< this 'pin'/signal is floating
-	IRQ_FLAG_USER		= (1 << 5), //!< Can be used by irq users
+	IRQ_FLAG_STRONG		= (1 << 5), //!< this 'pin'/signal is held at current state, do not "notify"
+	IRQ_FLAG_USER		= (1 << 6), //!< Can be used by irq users
 };
 
 /*


### PR DESCRIPTION
For USI two wire (TWI/I2C) mode:

Added the USI Start Detect functionality (SDA falling edge when SCL is high, and SDA pin in input mode) - Raises the Start interrupt vector.

Added the USI Stop Detect functionality (SDA rising edge when SCL is high, and SDA pin in input mode) - Sets the Stop interrupt flag.