### PR TITLE
flash: ignore SPM executed outside the boot loader section

### DIFF
--- a/simavr/cores/sim_mega2560.h
+++ b/simavr/cores/sim_mega2560.h
@@ -75,6 +75,8 @@ const struct mcu_t {
 	},
 	AVR_EEPROM_DECLARE(EE_READY_vect),
 	AVR_SELFPROG_DECLARE(SPMCSR, SPMEN, SPM_READY_vect),
+	// Boot loader section start (BOOTSZ=00, 8 KB): SPM below this is a no-op
+	.selfprog.bls_start = 0x3E000,
 	AVR_WATCHDOG_DECLARE(WDTCSR, WDT_vect),
 	.extint = {
 		AVR_EXTINT_MEGA_DECLARE(0, 'D', PD0, A),

--- a/simavr/sim/avr_flash.c
+++ b/simavr/sim/avr_flash.c
@@ -126,7 +126,12 @@ avr_flash_ioctl(
 			if (avr_regbit_get(avr, p->selfprgen)) {
 				avr_cycle_timer_cancel(avr, avr_progen_clear, p);
 
-				if (avr_regbit_get(avr, p->pgers)) {
+				if (p->bls_start && avr->pc < p->bls_start) {
+					// real hardware executes SPM only from the boot loader section
+					AVR_LOG(avr, LOG_WARNING,
+							"FLASH: SPM at PC=%06x ignored — outside the boot loader section (0x%06x+)\n",
+							avr->pc, p->bls_start);
+				} else if (avr_regbit_get(avr, p->pgers)) {
 					z &= ~(p->spm_pagesize - 1);
 					AVR_LOG(avr, LOG_TRACE, "FLASH: Erasing page %04x (%d)\n", (z / p->spm_pagesize), p->spm_pagesize);
 					for (int i = 0; i < p->spm_pagesize; i++)

--- a/simavr/sim/avr_flash.h
+++ b/simavr/sim/avr_flash.h
@@ -40,6 +40,10 @@ typedef struct avr_flash_t {
 	uint16_t	*tmppage;
 	uint8_t	*tmppage_used;
 	uint16_t	spm_pagesize;
+	// First byte address of the boot loader section. When non-zero, SPM
+	// executed with PC below this address is ignored, matching real
+	// hardware where SPM only works from the boot loader section.
+	avr_flashaddr_t	bls_start;
 	uint8_t r_spm;
 	avr_regbit_t selfprgen;
 	avr_regbit_t pgers;		// page erase


### PR DESCRIPTION
## Motivation

On real AVR silicon, the SPM instruction only executes when the program counter is inside the boot loader section; executed from the application (RWW) section it is a no-op. simavr currently executes SPM from any address.

This gap bit us in practice: an ATmega2560 bootloader accidentally linked at 0x3C000 (the boot section starts at 0x3E000 with BOOTSZ=00) passed a full simavr-based integration test suite — including complete STK500v2 and TFTP firmware-upload flows — while on real hardware every SPM was silently ignored and nothing was ever written to flash.

## Change

- `avr_flash_t` gets an opt-in `bls_start` field: when non-zero, SPM issued with `avr->pc` below it is ignored and a warning is logged.
- Cores that do not set the field keep the old permissive behaviour, so nothing changes for any other MCU.
- Enabled for the ATmega2560 core with the largest legal boot section (BOOTSZ=00, byte address 0x3E000). This is the most permissive boundary, so no valid fuse configuration is rejected, while SPM from the application section is caught.

Modelling the actual BOOTSZ fuse decoding would be more precise; this conservative boundary already catches the realistic failure mode (bootloader linked below the boot section) without touching fuse handling.

## Validation

- A probe firmware linked at 0x0000 that attempts `boot_page_erase`/`boot_page_fill`/`boot_page_write` via `<avr/boot.h>`: flash stays 0xFF after the patch (it was silently written before).
- Positive control: a real STK500v2+TFTP bootloader linked at 0x3E000 still programs flash correctly in simulation (full upload round-trips, verified against the same firmware running on physical ATmega2560 hardware).

🤖 Generated with [Claude Code](https://claude.com/claude-code)